### PR TITLE
243 making metrics query chaining work

### DIFF
--- a/src/teehr/evaluation/metrics.py
+++ b/src/teehr/evaluation/metrics.py
@@ -75,7 +75,6 @@ class Metrics:
         )
 
         if order_by is not None:
-            # ToDo: validate order_by fields
             logger.debug(f"Ordering the metrics by: {order_by}.")
             self.df = order_df(self.df, order_by)
 

--- a/src/teehr/evaluation/metrics.py
+++ b/src/teehr/evaluation/metrics.py
@@ -87,10 +87,10 @@ class Metrics:
     def to_geopandas(self) -> gpd.GeoDataFrame:
         """Convert the DataFrame to a GeoPandas DataFrame."""
         if "primary_location_id" not in self.df.columns:
-            raise ValueError(
-                "The primary_location_id field must be included in the "
-                "group_by to include geometry."
-            )
+            err_msg = "The primary_location_id field must be included in " \
+                      "the group_by to include geometry."
+            logger.error(err_msg)
+            raise ValueError(err_msg)
         return join_geometry(
             self.df,
             self.locations.to_sdf(),

--- a/src/teehr/evaluation/metrics.py
+++ b/src/teehr/evaluation/metrics.py
@@ -33,7 +33,7 @@ class Metrics:
         self.dataset_dir = eval.dataset_dir
         self.locations = eval.locations
         self.joined_timeseries = eval.joined_timeseries
-        self.df: ps.DataFrame = None
+        self.df = self.joined_timeseries.to_sdf()
 
     def query(
         self,
@@ -56,7 +56,6 @@ class Metrics:
     ):
         """Get the metrics in the dataset."""
         logger.info("Calculating performance metrics.")
-        self.df = self.joined_timeseries.to_sdf()
         if filters is not None:
             logger.debug("Applying filters to the metrics query.")
             self.df = validate_and_apply_filters(

--- a/src/teehr/metrics/metric_funcs.py
+++ b/src/teehr/metrics/metric_funcs.py
@@ -4,64 +4,34 @@ import numpy.typing as npt
 import pandas as pd
 
 
-def primary_count(p: pd.Series) -> float:
-    """Primary count."""
+def count(p: pd.Series) -> float:
+    """Count."""
     return len(p)
 
 
-def secondary_count(s: pd.Series) -> float:
-    """Secondary count."""
-    return len(s)
-
-
-def primary_minimum(p: pd.Series) -> float:
-    """Primary minimum."""
+def minimum(p: pd.Series) -> float:
+    """Minimum."""
     return np.min(p)
 
 
-def secondary_minimum(s: pd.Series) -> float:
-    """Secondary minimum."""
-    return np.min(s)
-
-
-def primary_maximum(p: pd.Series) -> float:
-    """Primary maximum."""
+def maximum(p: pd.Series) -> float:
+    """Maximum."""
     return np.max(p)
 
 
-def secondary_maximum(s: pd.Series) -> float:
-    """Secondary maximum."""
-    return np.max(s)
-
-
-def primary_average(p: pd.Series) -> float:
-    """Primary average."""
+def average(p: pd.Series) -> float:
+    """Average."""
     return np.mean(p)
 
 
-def secondary_average(s: pd.Series) -> float:
-    """Secondary average."""
-    return np.mean(s)
-
-
-def primary_sum(p: pd.Series) -> float:
-    """Primary sum."""
+def sum(p: pd.Series) -> float:
+    """Sum."""
     return np.sum(p)
 
 
-def secondary_sum(s: pd.Series) -> float:
-    """Secondary sum."""
-    return np.sum(s)
-
-
-def primary_variance(p: pd.Series) -> float:
-    """Primary variance."""
+def variance(p: pd.Series) -> float:
+    """Variance."""
     return np.var(p)
-
-
-def secondary_variance(s: pd.Series) -> float:
-    """Secondary variance."""
-    return np.var(s)
 
 
 def mean_error(p: pd.Series, s: pd.Series) -> float:
@@ -308,17 +278,17 @@ def max_value_timedelta(
     return td.total_seconds()
 
 
-def primary_max_value_time(
+def max_value_time(
     p: pd.Series,
     value_time: pd.Series
 ) -> pd.Timestamp:
-    """Primary max value time."""
+    """Max value time."""
     return value_time[p.idxmax()]
 
 
-def secondary_max_value_time(
-    s: pd.Series,
-    value_time: pd.Series
-) -> pd.Timestamp:
-    """Secondary max value time."""
-    return value_time[s.idxmax()]
+# def secondary_max_value_time(
+#     s: pd.Series,
+#     value_time: pd.Series
+# ) -> pd.Timestamp:
+#     """Secondary max value time."""
+#     return value_time[s.idxmax()]

--- a/src/teehr/models/metrics/metric_attributes.py
+++ b/src/teehr/models/metrics/metric_attributes.py
@@ -127,108 +127,54 @@ KGE2_ATTRS = {
     "return_type": "float"
 }
 
-PRIMARY_COUNT_ATTRS = {
-    "short_name": "primary_count",
-    "display_name": "Primary Count",
+COUNT_ATTRS = {
+    "short_name": "count",
+    "display_name": "Count",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,
     "return_type": "float"
 }
 
-SECONDARY_COUNT_ATTRS = {
-    "short_name": "secondary_count",
-    "display_name": "Secondary Count",
+MINIMUM_ATTRS = {
+    "short_name": "minimum",
+    "display_name": "Minimum",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,
     "return_type": "float"
 }
 
-PRIMARY_MINIMUM_ATTRS = {
-    "short_name": "primary_minimum",
-    "display_name": "Primary Minimum",
+MAXIMUM_ATTRS = {
+    "short_name": "maximum",
+    "display_name": "Maximum",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,
     "return_type": "float"
 }
 
-SECONDARY_MINIMUM_ATTRS = {
-    "short_name": "secondary_count",
-    "display_name": "Secondary Count",
+AVERAGE_ATTRS = {
+    "short_name": "average",
+    "display_name": "Average",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,
     "return_type": "float"
 }
 
-PRIMARY_MAXIMUM_ATTRS = {
-    "short_name": "primary_maximum",
-    "display_name": "Primary Maximum",
+SUM_ATTRS = {
+    "short_name": "sum",
+    "display_name": "Sum",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,
     "return_type": "float"
 }
 
-SECONDARY_MAXIMUM_ATTRS = {
-    "short_name": "secondary_maximum",
-    "display_name": "Secondary Maximum",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "float"
-}
-
-PRIMARY_AVERAGE_ATTRS = {
-    "short_name": "primary_average",
-    "display_name": "Primary Average",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "float"
-}
-
-SECONDARY_AVERAGE_ATTRS = {
-    "short_name": "secondary_average",
-    "display_name": "Secondary Average",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "float"
-}
-
-PRIMARY_SUM_ATTRS = {
-    "short_name": "primary_sum",
-    "display_name": "Primary Sum",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "float"
-}
-
-SECONDARY_SUM_ATTRS = {
-    "short_name": "secondary_sum",
-    "display_name": "Secondary Sum",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "float"
-}
-
-PRIMARY_VARIANCE_ATTRS = {
-    "short_name": "primary_variance",
-    "display_name": "Primary Variance",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "float"
-}
-
-SECONDARY_VARIANCE_ATTRS = {
-    "short_name": "secondary_variance",
-    "display_name": "Secondary Variance",
+VARIANCE_ATTRS = {
+    "short_name": "variance",
+    "display_name": "Variance",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,
@@ -244,18 +190,9 @@ MAX_VALUE_DELTA_ATTRS = {
     "return_type": "float"
 }
 
-PRIMARY_MAX_VAL_TIME_ATTRS = {
-    "short_name": "primary_max_val_time",
-    "display_name": "Primary Max Value Time",
-    "category": "Simple",
-    "value_range": None,
-    "optimal_value": None,
-    "return_type": "timestamp"
-}
-
-SECONDARY_MAX_VAL_TIME_ATTRS = {
-    "short_name": "secondary_max_val_time",
-    "display_name": "Secondary Max Value Time",
+MAX_VAL_TIME_ATTRS = {
+    "short_name": "max_val_time",
+    "display_name": "Max Value Time",
     "category": "Simple",
     "value_range": None,
     "optimal_value": None,

--- a/src/teehr/models/metrics/metric_models.py
+++ b/src/teehr/models/metrics/metric_models.py
@@ -486,8 +486,8 @@ class SPEARMAN_R(MetricsBasemodel):
     attrs: Dict = Field(default=tma.SPEARMAN_R_ATTRS, frozen=True)
 
 
-class PRIMARY_COUNT(MetricsBasemodel):
-    """Primary Count.
+class COUNT(MetricsBasemodel):
+    """Count.
 
     Parameters
     ----------
@@ -499,51 +499,23 @@ class PRIMARY_COUNT(MetricsBasemodel):
         The output field name, by default "primary_count".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_count.
+        metric_funcs.count.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
     """
 
-    output_field_name: str = Field(default="primary_count")
-    func: Callable = metric_funcs.primary_count
+    output_field_name: str = Field(default="count")
+    func: Callable = metric_funcs.count
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_COUNT_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.COUNT_ATTRS, frozen=True)
 
 
-class SECONDARY_COUNT(MetricsBasemodel):
-    """Secondary Count.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_count".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_count.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    output_field_name: str = Field(default="secondary_count")
-    func: Callable = metric_funcs.secondary_count
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_COUNT_ATTRS, frozen=True)
-
-
-class PRIMARY_MINIMUM(MetricsBasemodel):
-    """Primary Minimum.
+class MINIMUM(MetricsBasemodel):
+    """Minimum.
 
     Parameters
     ----------
@@ -555,7 +527,7 @@ class PRIMARY_MINIMUM(MetricsBasemodel):
         The output field name, by default "primary_minimum".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_minimum.
+        metric_funcs.minimum.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
@@ -563,45 +535,16 @@ class PRIMARY_MINIMUM(MetricsBasemodel):
     """
 
     transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="primary_minimum")
-    func: Callable = metric_funcs.primary_minimum
+    output_field_name: str = Field(default="minimum")
+    func: Callable = metric_funcs.minimum
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_MINIMUM_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.MINIMUM_ATTRS, frozen=True)
 
 
-class SECONDARY_MINIMUM(MetricsBasemodel):
-    """Secondary Minimum.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_minimum".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_minimum.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="secondary_minimum")
-    func: Callable = metric_funcs.secondary_minimum
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_MINIMUM_ATTRS, frozen=True)
-
-
-class PRIMARY_MAXIMUM(MetricsBasemodel):
-    """Primary Maximum.
+class MAXIMUM(MetricsBasemodel):
+    """Maximum.
 
     Parameters
     ----------
@@ -610,10 +553,10 @@ class PRIMARY_MAXIMUM(MetricsBasemodel):
     transform : TransformEnum
         The transformation to apply to the data, by default None.
     output_field_name : str
-        The output field name, by default "primary_maximum".
+        The output field name, by default "maximum".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_maximum.
+        metric_funcs.maximum.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
@@ -621,45 +564,16 @@ class PRIMARY_MAXIMUM(MetricsBasemodel):
     """
 
     transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="primary_maximum")
-    func: Callable = metric_funcs.primary_maximum
+    output_field_name: str = Field(default="maximum")
+    func: Callable = metric_funcs.maximum
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_MAXIMUM_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.MAXIMUM_ATTRS, frozen=True)
 
 
-class SECONDARY_MAXIMUM(MetricsBasemodel):
-    """Secondary Maximum.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_maximum".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_maximum.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="secondary_maximum")
-    func: Callable = metric_funcs.secondary_maximum
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_MAXIMUM_ATTRS, frozen=True)
-
-
-class PRIMARY_AVERAGE(MetricsBasemodel):
-    """Primary Average.
+class AVERAGE(MetricsBasemodel):
+    """Average.
 
     Parameters
     ----------
@@ -668,10 +582,10 @@ class PRIMARY_AVERAGE(MetricsBasemodel):
     transform : TransformEnum
         The transformation to apply to the data, by default None.
     output_field_name : str
-        The output field name, by default "primary_average".
+        The output field name, by default "average".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_average.
+        metric_funcs.average.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
@@ -679,45 +593,16 @@ class PRIMARY_AVERAGE(MetricsBasemodel):
     """
 
     transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="primary_average")
-    func: Callable = metric_funcs.primary_average
+    output_field_name: str = Field(default="average")
+    func: Callable = metric_funcs.average
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_AVERAGE_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.AVERAGE_ATTRS, frozen=True)
 
 
-class SECONDARY_AVERAGE(MetricsBasemodel):
-    """Secondary Average.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_average".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_average.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="secondary_average")
-    func: Callable = metric_funcs.secondary_average
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_AVERAGE_ATTRS, frozen=True)
-
-
-class PRIMARY_SUM(MetricsBasemodel):
-    """Primary Sum.
+class SUM(MetricsBasemodel):
+    """Sum.
 
     Parameters
     ----------
@@ -726,10 +611,10 @@ class PRIMARY_SUM(MetricsBasemodel):
     transform : TransformEnum
         The transformation to apply to the data, by default None.
     output_field_name : str
-        The output field name, by default "primary_sum".
+        The output field name, by default "sum".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_sum.
+        metric_funcs.sum.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
@@ -737,45 +622,16 @@ class PRIMARY_SUM(MetricsBasemodel):
     """
 
     transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="primary_sum")
-    func: Callable = metric_funcs.primary_sum
+    output_field_name: str = Field(default="sum")
+    func: Callable = metric_funcs.sum
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_SUM_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.SUM_ATTRS, frozen=True)
 
 
-class SECONDARY_SUM(MetricsBasemodel):
-    """Secondary Sum.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_sum".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_sum.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="secondary_sum")
-    func: Callable = metric_funcs.secondary_sum
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_SUM_ATTRS, frozen=True)
-
-
-class PRIMARY_VARIANCE(MetricsBasemodel):
-    """Primary Variance.
+class VARIANCE(MetricsBasemodel):
+    """Variance.
 
     Parameters
     ----------
@@ -784,10 +640,10 @@ class PRIMARY_VARIANCE(MetricsBasemodel):
     transform : TransformEnum
         The transformation to apply to the data, by default None.
     output_field_name : str
-        The output field name, by default "primary_variance".
+        The output field name, by default "variance".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_variance.
+        metric_funcs.variance.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
@@ -796,42 +652,12 @@ class PRIMARY_VARIANCE(MetricsBasemodel):
 
     bootstrap: MetricsBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="primary_variance")
-    func: Callable = metric_funcs.primary_variance
+    output_field_name: str = Field(default="variance")
+    func: Callable = metric_funcs.variance
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_VARIANCE_ATTRS, frozen=True)
-
-
-class SECONDARY_VARIANCE(MetricsBasemodel):
-    """Secondary Variance.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_variance".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_variance.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    bootstrap: MetricsBasemodel = Field(default=None)
-    transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="secondary_variance")
-    func: Callable = metric_funcs.secondary_variance
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_VARIANCE_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.VARIANCE_ATTRS, frozen=True)
 
 
 class MAX_VALUE_DELTA(MetricsBasemodel):
@@ -893,8 +719,8 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     attrs: Dict = Field(default=tma.MAX_VALUE_TIMEDELTA_ATTRS, frozen=True)
 
 
-class PRIMARY_MAX_VALUE_TIME(MetricsBasemodel):
-    """Primary Max Value Time.
+class MAX_VALUE_TIME(MetricsBasemodel):
+    """Max Value Time.
 
     Parameters
     ----------
@@ -903,52 +729,23 @@ class PRIMARY_MAX_VALUE_TIME(MetricsBasemodel):
     transform : TransformEnum
         The transformation to apply to the data, by default None.
     output_field_name : str
-        The output field name, by default "primary_max_value_time".
+        The output field name, by default "max_value_time".
     func : Callable
         The function to apply to the data, by default
-        metric_funcs.primary_max_value_time.
+        metric_funcs.max_value_time.
     input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["primary_value", "secondary_value"].
+        The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
     """
 
     transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="primary_max_value_time")
-    func: Callable = metric_funcs.primary_max_value_time
+    output_field_name: str = Field(default="max_value_time")
+    func: Callable = metric_funcs.max_value_time
     input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "value_time"]
     )
-    attrs: Dict = Field(default=tma.PRIMARY_MAX_VAL_TIME_ATTRS, frozen=True)
-
-
-class SECONDARY_MAX_VALUE_TIME(MetricsBasemodel):
-    """Secondary Max Value Time.
-
-    Parameters
-    ----------
-    bootstrap : MetricsBasemodel
-        The bootstrap model, by default None.
-    transform : TransformEnum
-        The transformation to apply to the data, by default None.
-    output_field_name : str
-        The output field name, by default "secondary_max_value_time".
-    func : Callable
-        The function to apply to the data, by default
-        metric_funcs.secondary_max_value_time.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
-        The input field names, by default ["secondary_value", "value_time"].
-    attrs : Dict
-        The static attributes for the metric.
-    """
-
-    transform: TransformEnum = Field(default=None)
-    output_field_name: str = Field(default="secondary_max_value_time")
-    func: Callable = metric_funcs.secondary_max_value_time
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
-        default=["secondary_value", "value_time"]
-    )
-    attrs: Dict = Field(default=tma.SECONDARY_MAX_VAL_TIME_ATTRS, frozen=True)
+    attrs: Dict = Field(default=tma.MAX_VAL_TIME_ATTRS, frozen=True)
 
 
 class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
@@ -997,23 +794,16 @@ class Metrics():
     MeanSquareError = MSE
     MultiplicativeBias = MULT_BIAS
     PearsonCorrelation = PEARSON_R
-    PrimaryAverage = PRIMARY_AVERAGE
-    PrimaryCount = PRIMARY_COUNT
-    PrimaryMaxValueTime = PRIMARY_MAX_VALUE_TIME
-    PrimaryMaximum = PRIMARY_MAXIMUM
-    PrimaryMinimum = PRIMARY_MINIMUM
-    PrimarySum = PRIMARY_SUM
-    PrimaryVariance = PRIMARY_VARIANCE
+    Average = AVERAGE
+    Count = COUNT
+    MaxValueTime = MAX_VALUE_TIME
+    Maximum = MAXIMUM
+    Minimum = MINIMUM
+    Sum = SUM
+    Variance = VARIANCE
     NashSutcliffeEfficiency = NSE
     NormalizedNashSutcliffeEfficiency = NNSE
     RelativeBias = REL_BIAS
     RootMeanSquareError = RMSE
     Rsquared = R2
-    SecondaryAverage = SECONDARY_AVERAGE
-    SecondaryCount = SECONDARY_COUNT
-    SecondaryMaximum = SECONDARY_MAXIMUM
-    SecondaryMaxValueTime = SECONDARY_MAX_VALUE_TIME
-    SecondaryMinimum = SECONDARY_MINIMUM
-    SecondarySum = SECONDARY_SUM
-    SecondaryVariance = SECONDARY_VARIANCE
     SpearmanCorrelation = SPEARMAN_R

--- a/src/teehr/models/metrics/metric_models.py
+++ b/src/teehr/models/metrics/metric_models.py
@@ -38,7 +38,7 @@ class ME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_error.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -48,7 +48,7 @@ class ME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_error")
     func: Callable = metric_funcs.mean_error
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.ME_ATTRS, frozen=True)
@@ -69,7 +69,7 @@ class REL_BIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.relative_bias.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -79,7 +79,7 @@ class REL_BIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="relative_bias")
     func: Callable = metric_funcs.relative_bias
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RBIAS_ATTRS, frozen=True)
@@ -100,7 +100,7 @@ class MULT_BIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.multiplicative_bias.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -110,7 +110,7 @@ class MULT_BIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="multiplicative_bias")
     func: Callable = metric_funcs.multiplicative_bias
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MULTBIAS_ATTRS, frozen=True)
@@ -131,7 +131,7 @@ class MSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_squared_error.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -141,7 +141,7 @@ class MSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_square_error")
     func: Callable = metric_funcs.mean_squared_error
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MSE_ATTRS, frozen=True)
@@ -162,7 +162,7 @@ class RMSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.root_mean_square_error.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -172,7 +172,7 @@ class RMSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="root_mean_square_error")
     func: Callable = metric_funcs.root_mean_squared_error
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RMSE_ATTRS, frozen=True)
@@ -193,7 +193,7 @@ class MAE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_absolute_error.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -203,7 +203,7 @@ class MAE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_error")
     func: Callable = metric_funcs.mean_absolute_error
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MAE_ATTRS, frozen=True)
@@ -224,7 +224,7 @@ class REL_MAE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_absolute_relative_error.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -234,7 +234,7 @@ class REL_MAE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_relative_error")
     func: Callable = metric_funcs.mean_absolute_relative_error
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RMAE_ATTRS, frozen=True)
@@ -255,7 +255,7 @@ class PEARSON_R(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.pearson_correlation.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -265,7 +265,7 @@ class PEARSON_R(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="pearson_correlation")
     func: Callable = metric_funcs.pearson_correlation
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.PEARSON_ATTRS, frozen=True)
@@ -286,7 +286,7 @@ class R2(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.r_squared.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -296,7 +296,7 @@ class R2(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="r_squared")
     func: Callable = metric_funcs.r_squared
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.R2_ATTRS, frozen=True)
@@ -317,7 +317,7 @@ class NSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.nash_sutcliffe_efficiency.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -327,7 +327,7 @@ class NSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="nash_sutcliffe_efficiency")
     func: Callable = metric_funcs.nash_sutcliffe_efficiency
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.NSE_ATTRS, frozen=True)
@@ -348,7 +348,7 @@ class NNSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.nash_sutcliffe_efficiency_normalized.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -360,7 +360,7 @@ class NNSE(MetricsBasemodel):
         default="nash_sutcliffe_efficiency_normalized"
     )
     func: Callable = metric_funcs.nash_sutcliffe_efficiency_normalized
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.NNSE_ATTRS, frozen=True)
@@ -380,7 +380,7 @@ class KGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -390,7 +390,7 @@ class KGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency")
     func: Callable = metric_funcs.kling_gupta_efficiency
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE_ATTRS, frozen=True)
@@ -410,7 +410,7 @@ class KGE_Mod1(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency_mod1.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -420,7 +420,7 @@ class KGE_Mod1(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod1")
     func: Callable = metric_funcs.kling_gupta_efficiency_mod1
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE1_ATTRS, frozen=True)
@@ -440,7 +440,7 @@ class KGE_Mod2(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency_mod2.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -450,7 +450,7 @@ class KGE_Mod2(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod2")
     func: Callable = metric_funcs.kling_gupta_efficiency_mod2
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE2_ATTRS, frozen=True)
@@ -470,7 +470,7 @@ class SPEARMAN_R(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.spearman_correlation.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -480,7 +480,7 @@ class SPEARMAN_R(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="spearman_correlation")
     func: Callable = metric_funcs.spearman_correlation
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.SPEARMAN_R_ATTRS, frozen=True)
@@ -500,7 +500,7 @@ class COUNT(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.count.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -508,7 +508,7 @@ class COUNT(MetricsBasemodel):
 
     output_field_name: str = Field(default="count")
     func: Callable = metric_funcs.count
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.COUNT_ATTRS, frozen=True)
@@ -528,7 +528,7 @@ class MINIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.minimum.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -537,7 +537,7 @@ class MINIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="minimum")
     func: Callable = metric_funcs.minimum
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.MINIMUM_ATTRS, frozen=True)
@@ -557,7 +557,7 @@ class MAXIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.maximum.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -566,7 +566,7 @@ class MAXIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="maximum")
     func: Callable = metric_funcs.maximum
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.MAXIMUM_ATTRS, frozen=True)
@@ -586,7 +586,7 @@ class AVERAGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.average.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -595,7 +595,7 @@ class AVERAGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="average")
     func: Callable = metric_funcs.average
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.AVERAGE_ATTRS, frozen=True)
@@ -615,7 +615,7 @@ class SUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.sum.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -624,7 +624,7 @@ class SUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="sum")
     func: Callable = metric_funcs.sum
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.SUM_ATTRS, frozen=True)
@@ -644,7 +644,7 @@ class VARIANCE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.variance.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -654,7 +654,7 @@ class VARIANCE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="variance")
     func: Callable = metric_funcs.variance
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.VARIANCE_ATTRS, frozen=True)
@@ -674,7 +674,7 @@ class MAX_VALUE_DELTA(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_delta.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -683,7 +683,7 @@ class MAX_VALUE_DELTA(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_delta")
     func: Callable = metric_funcs.max_value_delta
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MAX_VALUE_DELTA_ATTRS, frozen=True)
@@ -703,7 +703,7 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_timedelta.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default
         ["primary_value", "secondary_value", "value_time"].
     attrs : Dict
@@ -713,7 +713,7 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time_delta")
     func: Callable = metric_funcs.max_value_timedelta
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.MAX_VALUE_TIMEDELTA_ATTRS, frozen=True)
@@ -733,7 +733,7 @@ class MAX_VALUE_TIME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_time.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -742,7 +742,7 @@ class MAX_VALUE_TIME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time")
     func: Callable = metric_funcs.max_value_time
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.MAX_VAL_TIME_ATTRS, frozen=True)
@@ -762,7 +762,7 @@ class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.annual_peak_relative_bias.
-    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
+    input_field_names : Union[List[str], JoinedTimeseriesFields]
         The input field names, by default
         ["primary_value", "secondary_value", "value_time"].
     attrs : Dict
@@ -773,7 +773,7 @@ class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="annual_peak_flow_bias")
     func: Callable = metric_funcs.annual_peak_relative_bias
-    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
+    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.ANNUAL_PEAK_RBIAS_ATTRS, frozen=True)

--- a/src/teehr/models/metrics/metric_models.py
+++ b/src/teehr/models/metrics/metric_models.py
@@ -38,7 +38,7 @@ class ME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_error.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -48,7 +48,7 @@ class ME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_error")
     func: Callable = metric_funcs.mean_error
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.ME_ATTRS, frozen=True)
@@ -69,7 +69,7 @@ class REL_BIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.relative_bias.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -79,7 +79,7 @@ class REL_BIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="relative_bias")
     func: Callable = metric_funcs.relative_bias
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RBIAS_ATTRS, frozen=True)
@@ -100,7 +100,7 @@ class MULT_BIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.multiplicative_bias.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -110,7 +110,7 @@ class MULT_BIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="multiplicative_bias")
     func: Callable = metric_funcs.multiplicative_bias
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MULTBIAS_ATTRS, frozen=True)
@@ -131,7 +131,7 @@ class MSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_squared_error.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -141,7 +141,7 @@ class MSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_square_error")
     func: Callable = metric_funcs.mean_squared_error
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MSE_ATTRS, frozen=True)
@@ -162,7 +162,7 @@ class RMSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.root_mean_square_error.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -172,7 +172,7 @@ class RMSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="root_mean_square_error")
     func: Callable = metric_funcs.root_mean_squared_error
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RMSE_ATTRS, frozen=True)
@@ -193,7 +193,7 @@ class MAE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_absolute_error.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -203,7 +203,7 @@ class MAE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_error")
     func: Callable = metric_funcs.mean_absolute_error
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MAE_ATTRS, frozen=True)
@@ -224,7 +224,7 @@ class REL_MAE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_absolute_relative_error.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -234,7 +234,7 @@ class REL_MAE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_relative_error")
     func: Callable = metric_funcs.mean_absolute_relative_error
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RMAE_ATTRS, frozen=True)
@@ -255,7 +255,7 @@ class PEARSON_R(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.pearson_correlation.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -265,7 +265,7 @@ class PEARSON_R(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="pearson_correlation")
     func: Callable = metric_funcs.pearson_correlation
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.PEARSON_ATTRS, frozen=True)
@@ -286,7 +286,7 @@ class R2(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.r_squared.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -296,7 +296,7 @@ class R2(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="r_squared")
     func: Callable = metric_funcs.r_squared
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.R2_ATTRS, frozen=True)
@@ -317,7 +317,7 @@ class NSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.nash_sutcliffe_efficiency.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -327,7 +327,7 @@ class NSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="nash_sutcliffe_efficiency")
     func: Callable = metric_funcs.nash_sutcliffe_efficiency
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.NSE_ATTRS, frozen=True)
@@ -348,7 +348,7 @@ class NNSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.nash_sutcliffe_efficiency_normalized.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -360,7 +360,7 @@ class NNSE(MetricsBasemodel):
         default="nash_sutcliffe_efficiency_normalized"
     )
     func: Callable = metric_funcs.nash_sutcliffe_efficiency_normalized
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.NNSE_ATTRS, frozen=True)
@@ -380,7 +380,7 @@ class KGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -390,7 +390,7 @@ class KGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency")
     func: Callable = metric_funcs.kling_gupta_efficiency
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE_ATTRS, frozen=True)
@@ -410,7 +410,7 @@ class KGE_Mod1(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency_mod1.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -420,7 +420,7 @@ class KGE_Mod1(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod1")
     func: Callable = metric_funcs.kling_gupta_efficiency_mod1
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE1_ATTRS, frozen=True)
@@ -440,7 +440,7 @@ class KGE_Mod2(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency_mod2.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -450,7 +450,7 @@ class KGE_Mod2(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod2")
     func: Callable = metric_funcs.kling_gupta_efficiency_mod2
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE2_ATTRS, frozen=True)
@@ -470,7 +470,7 @@ class SPEARMAN_R(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.spearman_correlation.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -480,7 +480,7 @@ class SPEARMAN_R(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="spearman_correlation")
     func: Callable = metric_funcs.spearman_correlation
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.SPEARMAN_R_ATTRS, frozen=True)
@@ -500,7 +500,7 @@ class PRIMARY_COUNT(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_count.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -508,7 +508,7 @@ class PRIMARY_COUNT(MetricsBasemodel):
 
     output_field_name: str = Field(default="primary_count")
     func: Callable = metric_funcs.primary_count
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_COUNT_ATTRS, frozen=True)
@@ -528,7 +528,7 @@ class SECONDARY_COUNT(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_count.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -536,7 +536,7 @@ class SECONDARY_COUNT(MetricsBasemodel):
 
     output_field_name: str = Field(default="secondary_count")
     func: Callable = metric_funcs.secondary_count
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_COUNT_ATTRS, frozen=True)
@@ -556,7 +556,7 @@ class PRIMARY_MINIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_minimum.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -565,7 +565,7 @@ class PRIMARY_MINIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="primary_minimum")
     func: Callable = metric_funcs.primary_minimum
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_MINIMUM_ATTRS, frozen=True)
@@ -585,7 +585,7 @@ class SECONDARY_MINIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_minimum.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -594,7 +594,7 @@ class SECONDARY_MINIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="secondary_minimum")
     func: Callable = metric_funcs.secondary_minimum
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_MINIMUM_ATTRS, frozen=True)
@@ -614,7 +614,7 @@ class PRIMARY_MAXIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_maximum.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -623,7 +623,7 @@ class PRIMARY_MAXIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="primary_maximum")
     func: Callable = metric_funcs.primary_maximum
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_MAXIMUM_ATTRS, frozen=True)
@@ -643,7 +643,7 @@ class SECONDARY_MAXIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_maximum.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -652,7 +652,7 @@ class SECONDARY_MAXIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="secondary_maximum")
     func: Callable = metric_funcs.secondary_maximum
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_MAXIMUM_ATTRS, frozen=True)
@@ -672,7 +672,7 @@ class PRIMARY_AVERAGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_average.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -681,7 +681,7 @@ class PRIMARY_AVERAGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="primary_average")
     func: Callable = metric_funcs.primary_average
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_AVERAGE_ATTRS, frozen=True)
@@ -701,7 +701,7 @@ class SECONDARY_AVERAGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_average.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -710,7 +710,7 @@ class SECONDARY_AVERAGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="secondary_average")
     func: Callable = metric_funcs.secondary_average
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_AVERAGE_ATTRS, frozen=True)
@@ -730,7 +730,7 @@ class PRIMARY_SUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_sum.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -739,7 +739,7 @@ class PRIMARY_SUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="primary_sum")
     func: Callable = metric_funcs.primary_sum
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_SUM_ATTRS, frozen=True)
@@ -759,7 +759,7 @@ class SECONDARY_SUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_sum.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -768,7 +768,7 @@ class SECONDARY_SUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="secondary_sum")
     func: Callable = metric_funcs.secondary_sum
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_SUM_ATTRS, frozen=True)
@@ -788,7 +788,7 @@ class PRIMARY_VARIANCE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_variance.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -798,7 +798,7 @@ class PRIMARY_VARIANCE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="primary_variance")
     func: Callable = metric_funcs.primary_variance
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_VARIANCE_ATTRS, frozen=True)
@@ -818,7 +818,7 @@ class SECONDARY_VARIANCE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_variance.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -828,7 +828,7 @@ class SECONDARY_VARIANCE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="secondary_variance")
     func: Callable = metric_funcs.secondary_variance
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_VARIANCE_ATTRS, frozen=True)
@@ -848,7 +848,7 @@ class MAX_VALUE_DELTA(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_delta.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -857,7 +857,7 @@ class MAX_VALUE_DELTA(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_delta")
     func: Callable = metric_funcs.max_value_delta
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MAX_VALUE_DELTA_ATTRS, frozen=True)
@@ -877,7 +877,7 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_timedelta.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default
         ["primary_value", "secondary_value", "value_time"].
     attrs : Dict
@@ -887,7 +887,7 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time_delta")
     func: Callable = metric_funcs.max_value_timedelta
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.MAX_VALUE_TIMEDELTA_ATTRS, frozen=True)
@@ -907,7 +907,7 @@ class PRIMARY_MAX_VALUE_TIME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.primary_max_value_time.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -916,7 +916,7 @@ class PRIMARY_MAX_VALUE_TIME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="primary_max_value_time")
     func: Callable = metric_funcs.primary_max_value_time
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.PRIMARY_MAX_VAL_TIME_ATTRS, frozen=True)
@@ -936,7 +936,7 @@ class SECONDARY_MAX_VALUE_TIME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.secondary_max_value_time.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default ["secondary_value", "value_time"].
     attrs : Dict
         The static attributes for the metric.
@@ -945,7 +945,7 @@ class SECONDARY_MAX_VALUE_TIME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="secondary_max_value_time")
     func: Callable = metric_funcs.secondary_max_value_time
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.SECONDARY_MAX_VAL_TIME_ATTRS, frozen=True)
@@ -965,7 +965,7 @@ class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.annual_peak_relative_bias.
-    input_field_names : List[JoinedTimeseriesFields]
+    input_field_names : Union[List[str], List[JoinedTimeseriesFields]]
         The input field names, by default
         ["primary_value", "secondary_value", "value_time"].
     attrs : Dict
@@ -976,7 +976,7 @@ class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="annual_peak_flow_bias")
     func: Callable = metric_funcs.annual_peak_relative_bias
-    input_field_names: List[JoinedTimeseriesFields] = Field(
+    input_field_names: Union[List[str], List[JoinedTimeseriesFields]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.ANNUAL_PEAK_RBIAS_ATTRS, frozen=True)

--- a/src/teehr/querying/utils.py
+++ b/src/teehr/querying/utils.py
@@ -40,17 +40,19 @@ def validate_fields_exist(
         requested_fields: List[str]
 ):
     """Validate that the requested_fields are in the valid_fields list."""
+    logger.debug("Validating requested fields.")
     if not all(e in valid_fields for e in requested_fields):
-        raise ValueError(
-            f"One of the requested fields: {requested_fields} is not a valid"
-            f" DataFrame field: {valid_fields}."
-        )
+        error_msg = f"One of the requested fields: {requested_fields} is not" \
+                    f" a valid DataFrame field: {valid_fields}."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def parse_fields_to_list(
         requested_fields: Union[str, StrEnum, List[Union[str, StrEnum]]]
 ) -> List[str]:
     """Convert the requested fields to a list of strings."""
+    logger.debug("Parsing requested fields to a list of strings.")
     if not isinstance(requested_fields, List):
         requested_fields = [requested_fields]
     requested_fields_strings = []
@@ -64,6 +66,7 @@ def parse_fields_to_list(
 
 def order_df(df, sort_by: Union[str, StrEnum, List[Union[str, StrEnum]]]):
     """Sort a DataFrame by a list of columns."""
+    logger.debug("Ordering DataFrame.")
     sort_by_strings = parse_fields_to_list(sort_by)
     validate_fields_exist(df.columns, sort_by_strings)
     return df.orderBy(*sort_by_strings)
@@ -71,6 +74,7 @@ def order_df(df, sort_by: Union[str, StrEnum, List[Union[str, StrEnum]]]):
 
 def group_df(df, group_by: Union[str, StrEnum, List[Union[str, StrEnum]]]):
     """Group a DataFrame by a list of columns."""
+    logger.debug("Grouping DataFrame.")
     group_by_strings = parse_fields_to_list(group_by)
     validate_fields_exist(df.columns, group_by_strings)
     return df.groupBy(*group_by_strings)

--- a/src/teehr/querying/utils.py
+++ b/src/teehr/querying/utils.py
@@ -35,31 +35,39 @@ def df_to_gdf(df: pd.DataFrame) -> gpd.GeoDataFrame:
     return gpd.GeoDataFrame(df, crs="EPSG:4326", geometry="geometry")
 
 
+def _parse_fields_to_list(
+        valid_fields: List[str],
+        requested_fields: Union[str, StrEnum, List[Union[str, StrEnum]]]
+) -> List[str]:
+    """Convert the requested fields to a list of strings.
+
+    Additionally validate that the requested fields are in the DataFrame.
+    """
+    if not isinstance(requested_fields, List):
+        requested_fields = [requested_fields]
+    requested_fields_strings = []
+    for field in requested_fields:
+        if isinstance(field, str):
+            requested_fields_strings.append(field)
+        else:
+            requested_fields_strings.append(field.value)
+    if not all(e in valid_fields for e in requested_fields):
+        raise ValueError(
+            f"One of the requested fields: {requested_fields} does not exist"
+            f" in the DataFrame: {valid_fields}."
+        )
+    return requested_fields_strings
+
+
 def order_df(df, sort_by: Union[str, StrEnum, List[Union[str, StrEnum]]]):
     """Sort a DataFrame by a list of columns."""
-    if not isinstance(sort_by, List):
-        sort_by = [sort_by]
-    sort_by_strings = []
-    for field in sort_by:
-        if isinstance(field, str):
-            sort_by_strings.append(field)
-        else:
-            sort_by_strings.append(field.value)
-
+    sort_by_strings = _parse_fields_to_list(df.columns, sort_by)
     return df.orderBy(*sort_by_strings)
 
 
 def group_df(df, group_by: Union[str, StrEnum, List[Union[str, StrEnum]]]):
     """Group a DataFrame by a list of columns."""
-    if not isinstance(group_by, List):
-        group_by = [group_by]
-    group_by_strings = []
-    for field in group_by:
-        if isinstance(field, str):
-            group_by_strings.append(field)
-        else:
-            group_by_strings.append(field.value)
-
+    group_by_strings = _parse_fields_to_list(df.columns, group_by)
     return df.groupBy(*group_by_strings)
 
 

--- a/tests/test_get_metrics_query.py
+++ b/tests/test_get_metrics_query.py
@@ -311,7 +311,36 @@ def test_gumboot_bootstrapping(tmpdir):
     r_kge_vals = np.sort(r_df.KGE.values)
     assert np.allclose(teehr_results, r_kge_vals, rtol=1e-08)
 
-    pass
+
+def test_metric_chaining(tmpdir):
+    """Test get_metrics method with chaining."""
+    # Define the evaluation object.
+    eval = setup_v0_3_study(tmpdir)
+
+    # Test chaining.
+    metrics_df = eval.metrics.query(
+        order_by=["primary_location_id", "month"],
+        group_by=["primary_location_id", "month"],
+        include_metrics=[
+            Metrics.KlingGuptaEfficiency(),
+            Metrics.NashSutcliffeEfficiency(),
+            Metrics.RelativeBias()
+        ]
+    ).query(
+        order_by=["primary_location_id"],
+        group_by=["primary_location_id"],
+        include_metrics=[
+            Metrics.PrimaryAverage(
+                input_field_names=["relative_bias"]
+            )
+        ]
+    ).to_pandas()
+
+    assert isinstance(metrics_df, pd.DataFrame)
+    assert metrics_df.index.size == 3
+    assert all(
+        metrics_df.columns == ["primary_location_id", "primary_average"]
+    )
 
 
 
@@ -346,6 +375,12 @@ if __name__ == "__main__":
         test_gumboot_bootstrapping(
             tempfile.mkdtemp(
                 prefix="5-",
+                dir=tempdir
+            )
+        )
+        test_metric_chaining(
+            tempfile.mkdtemp(
+                prefix="6-",
                 dir=tempdir
             )
         )

--- a/tests/test_get_metrics_query.py
+++ b/tests/test_get_metrics_query.py
@@ -54,7 +54,7 @@ def test_get_all_metrics(tmpdir):
 
     assert isinstance(metrics_df, pd.DataFrame)
     assert metrics_df.index.size == 3
-    assert metrics_df.columns.size == 33
+    assert metrics_df.columns.size == 26
 
 
 def test_metrics_filter_and_geometry(tmpdir):
@@ -64,9 +64,9 @@ def test_metrics_filter_and_geometry(tmpdir):
 
     # Define some metrics.
     kge = Metrics.KlingGuptaEfficiency()
-    primary_avg = Metrics.PrimaryAverage()
+    primary_avg = Metrics.Average()
     mvtd = Metrics.MaxValueTimeDelta()
-    pmvt = Metrics.PrimaryMaxValueTime()
+    pmvt = Metrics.MaxValueTime()
 
     include_metrics = [pmvt, mvtd, primary_avg, kge]
 
@@ -330,8 +330,9 @@ def test_metric_chaining(tmpdir):
         order_by=["primary_location_id"],
         group_by=["primary_location_id"],
         include_metrics=[
-            Metrics.PrimaryAverage(
-                input_field_names=["relative_bias"]
+            Metrics.Average(
+                input_field_names=["relative_bias"],
+                output_field_name="primary_average"
             )
         ]
     ).to_pandas()

--- a/tests/test_get_metrics_query.py
+++ b/tests/test_get_metrics_query.py
@@ -344,7 +344,6 @@ def test_metric_chaining(tmpdir):
     )
 
 
-
 if __name__ == "__main__":
     with tempfile.TemporaryDirectory(
         prefix="teehr-"


### PR DESCRIPTION
* Fixes metric query chaining by moving `self.df` assignment from `query()` to  `__init__()`
* Adds a test for chaining metric queries
* Adds validation to requested order_by and group_by fields, ensuring they exist
* Adds validation to metric `input_field_names`, ensuring they exist
* Removes redundant metric models (ie, PrimaryAverage/SecondaryAverage --> Average, PrimarySum/SecondarySum --> Sum, …)
* Allows `input_field_names` to accept a list of strings in addition the `JoinedTimeseriesFields` field enum

Addresses issues #249 , #243 , and #242
