### PR TITLE
252 simple metrics seem to ignore input field name

### DIFF
--- a/src/teehr/metrics/gumboot_bootstrap.py
+++ b/src/teehr/metrics/gumboot_bootstrap.py
@@ -79,7 +79,6 @@ class GumbootBootstrap(IIDBootstrap):
         This requires an extra field (value_time) to create indices based on
         water year (time).
         """
-
         logger.debug(f"Resampling the Gumboot water years. rep: {rep}")
 
         if rep == 0:

--- a/src/teehr/models/metrics/bootstrap_models.py
+++ b/src/teehr/models/metrics/bootstrap_models.py
@@ -2,7 +2,6 @@
 from typing import Callable, List, Union
 from pathlib import Path
 
-from arch.typing import ArrayLike
 from numpy.random import RandomState
 from pydantic import Field
 
@@ -15,16 +14,17 @@ from teehr.models.metrics.metric_models import MetricsBasemodel
 class GumbootModel(MetricsBasemodel):
     """Gumboot bootstrapping.
 
-    This is a partial implementation of the Gumboot R package, a non-overlapping
-    bootstrap method where blocks are defined by water years. Synthetic timeseries
-    are constructed by randomly resampling water years from the input timeseries
-    with replacement. The specified performance metric is calculated for each
-    synthetic timeseries for a number of bootstrap replications (reps). The
-    quantiles of the bootstrap metric results are calculated and returned.
+    This is a partial implementation of the Gumboot R package, a
+    non-overlapping bootstrap method where blocks are defined by water
+    years. Synthetic timeseries are constructed by randomly resampling water
+    years from the input timeseries with replacement. The specified performance
+    metric is calculated for each synthetic timeseries for a number of
+    bootstrap replications (reps). The quantiles of the bootstrap metric
+    results are calculated and returned.
 
-    If the quantile values are not specified or are set to None, the array of metric
-    values is returned (dimensions: [reps, 1]). Otherwise the specified quantiles of
-    the metric values are returned as a dictionary.
+    If the quantile values are not specified or are set to None, the array
+    of metric values is returned (dimensions: [reps, 1]). Otherwise the
+    specified quantiles of the metric values are returned as a dictionary.
 
     See Also:  Clark et al. (2021), "The abuse of popular performance metrics
       in hydrologic modeling", Water Resources Research,
@@ -36,13 +36,13 @@ class GumbootModel(MetricsBasemodel):
     ----------
     reps : int
         The number of bootstrap replications. Default value is 1000.
-    seed : int, optional
-        The seed for the random number generator. Setting a seed value can be used
-        to provide reproducible results. Default value is None.
-    quantiles : List[float], optional
-        The quantiles to calculate from the bootstrap metric results. The default
-        value is None.
-    boot_year_file : Union[str, Path, None], optional
+    seed : Union[int, None]
+        The seed for the random number generator. Setting a seed value can be
+        used to provide reproducible results. Default value is None.
+    quantiles : Union[List[float], None]
+        The quantiles to calculate from the bootstrap metric results. The
+        default value is None.
+    boot_year_file : Union[str, Path, None]
         The file path to the boot year csv file. The default value is None.
     water_year_month : int
         The month specifying the start of the water year. Default value is 10.
@@ -73,8 +73,8 @@ class CircularBlockModel(MetricsBasemodel):
 
     Parameters
     ----------
-    seed : int
-        The seed for the random number generator.
+    seed : Union[int, None]
+        The seed for the random number generator. Default value is None.
     random_state : RandomState, optional
         The random state for the random number generator.
     reps : int
@@ -82,7 +82,8 @@ class CircularBlockModel(MetricsBasemodel):
     block_size : int
         The block size for the CircularBlockBootstrap.
     quantiles : List[float]
-        The quantiles to calculate from the bootstrap results
+        The quantiles to calculate from the bootstrap results. Default
+        value is None.
     name : str
         The name of the bootstrap method. Currently only used in
         logging. Default value is "CircularBlock".
@@ -93,11 +94,11 @@ class CircularBlockModel(MetricsBasemodel):
         The wrapper to generate the bootstrapping function.
     """
 
-    seed: int = 42
+    seed: Union[int, None] = None
     random_state: Union[RandomState, None] = None
     reps: int = 1000
     block_size: int = 365
-    quantiles: Union[List[float], None] = [0.05, 0.5, 0.95]
+    quantiles: Union[List[float], None] = None
     name: str = Field(default="CircularBlock")
     include_value_time: bool = Field(False, frozen=True)
     func: Callable = Field(
@@ -105,13 +106,14 @@ class CircularBlockModel(MetricsBasemodel):
         frozen=True
     )
 
+
 class StationaryModel(MetricsBasemodel):
     """Stationary bootstrapping from the arch python package.
 
     Parameters
     ----------
-    seed : int
-        The seed for the random number generator.
+    seed : Union[int, None]
+        The seed for the random number generator. Default value is 42.
     random_state : RandomState, optional
         The random state for the random number generator.
     reps : int
@@ -119,7 +121,8 @@ class StationaryModel(MetricsBasemodel):
     block_size : int
         The block size for the StationaryBootstrap.
     quantiles : List[float]
-        The quantiles to calculate from the bootstrap results
+        The quantiles to calculate from the bootstrap results. Default
+        value is None.
     name : str
         The name of the bootstrap method. Currently only used in
         logging. Default value is "Stationary".
@@ -130,11 +133,11 @@ class StationaryModel(MetricsBasemodel):
         The wrapper to generate the bootstrapping function.
     """
 
-    seed: int = 42
+    seed: Union[int, None] = None
     random_state: Union[RandomState, None] = None
     reps: int = 1000
     block_size: int = 365
-    quantiles: Union[List[float], None] = [0.05, 0.5, 0.95]
+    quantiles: Union[List[float], None] = None
     name: str = Field(default="Stationary")
     include_value_time: bool = Field(False, frozen=True)
     func: Callable = Field(

--- a/src/teehr/models/metrics/metric_models.py
+++ b/src/teehr/models/metrics/metric_models.py
@@ -8,9 +8,7 @@ from teehr.models.metrics.metric_enums import (
     TransformEnum
 )
 from teehr.metrics import metric_funcs as metric_funcs
-from teehr.models.table_enums import (
-    JoinedTimeseriesFields
-)
+from teehr.models.str_enum import StrEnum
 
 
 class MetricsBasemodel(PydanticBaseModel):
@@ -19,7 +17,7 @@ class MetricsBasemodel(PydanticBaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         validate_assignment=True,
-        # extra='forbid'  # raise an error if extra fields are passed
+        extra='forbid'  # raise an error if extra fields are passed
     )
 
 
@@ -38,7 +36,7 @@ class ME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_error.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -48,7 +46,7 @@ class ME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_error")
     func: Callable = metric_funcs.mean_error
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.ME_ATTRS, frozen=True)
@@ -69,7 +67,7 @@ class REL_BIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.relative_bias.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -79,7 +77,7 @@ class REL_BIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="relative_bias")
     func: Callable = metric_funcs.relative_bias
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RBIAS_ATTRS, frozen=True)
@@ -100,7 +98,7 @@ class MULT_BIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.multiplicative_bias.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -110,7 +108,7 @@ class MULT_BIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="multiplicative_bias")
     func: Callable = metric_funcs.multiplicative_bias
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MULTBIAS_ATTRS, frozen=True)
@@ -131,7 +129,7 @@ class MSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_squared_error.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -141,7 +139,7 @@ class MSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_square_error")
     func: Callable = metric_funcs.mean_squared_error
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MSE_ATTRS, frozen=True)
@@ -162,7 +160,7 @@ class RMSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.root_mean_square_error.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -172,7 +170,7 @@ class RMSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="root_mean_square_error")
     func: Callable = metric_funcs.root_mean_squared_error
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RMSE_ATTRS, frozen=True)
@@ -193,7 +191,7 @@ class MAE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_absolute_error.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -203,7 +201,7 @@ class MAE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_error")
     func: Callable = metric_funcs.mean_absolute_error
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MAE_ATTRS, frozen=True)
@@ -224,7 +222,7 @@ class REL_MAE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.mean_absolute_relative_error.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -234,7 +232,7 @@ class REL_MAE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_relative_error")
     func: Callable = metric_funcs.mean_absolute_relative_error
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.RMAE_ATTRS, frozen=True)
@@ -255,7 +253,7 @@ class PEARSON_R(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.pearson_correlation.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -265,7 +263,7 @@ class PEARSON_R(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="pearson_correlation")
     func: Callable = metric_funcs.pearson_correlation
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.PEARSON_ATTRS, frozen=True)
@@ -286,7 +284,7 @@ class R2(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.r_squared.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -296,7 +294,7 @@ class R2(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="r_squared")
     func: Callable = metric_funcs.r_squared
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.R2_ATTRS, frozen=True)
@@ -317,7 +315,7 @@ class NSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.nash_sutcliffe_efficiency.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -327,7 +325,7 @@ class NSE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="nash_sutcliffe_efficiency")
     func: Callable = metric_funcs.nash_sutcliffe_efficiency
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.NSE_ATTRS, frozen=True)
@@ -348,7 +346,7 @@ class NNSE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.nash_sutcliffe_efficiency_normalized.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -360,7 +358,7 @@ class NNSE(MetricsBasemodel):
         default="nash_sutcliffe_efficiency_normalized"
     )
     func: Callable = metric_funcs.nash_sutcliffe_efficiency_normalized
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.NNSE_ATTRS, frozen=True)
@@ -380,7 +378,7 @@ class KGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -390,7 +388,7 @@ class KGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency")
     func: Callable = metric_funcs.kling_gupta_efficiency
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE_ATTRS, frozen=True)
@@ -410,7 +408,7 @@ class KGE_Mod1(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency_mod1.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -420,7 +418,7 @@ class KGE_Mod1(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod1")
     func: Callable = metric_funcs.kling_gupta_efficiency_mod1
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE1_ATTRS, frozen=True)
@@ -440,7 +438,7 @@ class KGE_Mod2(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.kling_gupta_efficiency_mod2.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -450,7 +448,7 @@ class KGE_Mod2(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod2")
     func: Callable = metric_funcs.kling_gupta_efficiency_mod2
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.KGE2_ATTRS, frozen=True)
@@ -470,7 +468,7 @@ class SPEARMAN_R(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.spearman_correlation.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -480,7 +478,7 @@ class SPEARMAN_R(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="spearman_correlation")
     func: Callable = metric_funcs.spearman_correlation
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.SPEARMAN_R_ATTRS, frozen=True)
@@ -500,7 +498,7 @@ class COUNT(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.count.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -508,7 +506,7 @@ class COUNT(MetricsBasemodel):
 
     output_field_name: str = Field(default="count")
     func: Callable = metric_funcs.count
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.COUNT_ATTRS, frozen=True)
@@ -528,7 +526,7 @@ class MINIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.minimum.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -537,7 +535,7 @@ class MINIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="minimum")
     func: Callable = metric_funcs.minimum
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.MINIMUM_ATTRS, frozen=True)
@@ -557,7 +555,7 @@ class MAXIMUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.maximum.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -566,7 +564,7 @@ class MAXIMUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="maximum")
     func: Callable = metric_funcs.maximum
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.MAXIMUM_ATTRS, frozen=True)
@@ -586,7 +584,7 @@ class AVERAGE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.average.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -595,7 +593,7 @@ class AVERAGE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="average")
     func: Callable = metric_funcs.average
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.AVERAGE_ATTRS, frozen=True)
@@ -615,7 +613,7 @@ class SUM(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.sum.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -624,7 +622,7 @@ class SUM(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="sum")
     func: Callable = metric_funcs.sum
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.SUM_ATTRS, frozen=True)
@@ -644,7 +642,7 @@ class VARIANCE(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.variance.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -654,7 +652,7 @@ class VARIANCE(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="variance")
     func: Callable = metric_funcs.variance
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
     attrs: Dict = Field(default=tma.VARIANCE_ATTRS, frozen=True)
@@ -674,7 +672,7 @@ class MAX_VALUE_DELTA(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_delta.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value", "secondary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -683,7 +681,7 @@ class MAX_VALUE_DELTA(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_delta")
     func: Callable = metric_funcs.max_value_delta
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
     attrs: Dict = Field(default=tma.MAX_VALUE_DELTA_ATTRS, frozen=True)
@@ -703,7 +701,7 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_timedelta.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default
         ["primary_value", "secondary_value", "value_time"].
     attrs : Dict
@@ -713,7 +711,7 @@ class MAX_VALUE_TIME_DELTA(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time_delta")
     func: Callable = metric_funcs.max_value_timedelta
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.MAX_VALUE_TIMEDELTA_ATTRS, frozen=True)
@@ -733,7 +731,7 @@ class MAX_VALUE_TIME(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.max_value_time.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default ["primary_value"].
     attrs : Dict
         The static attributes for the metric.
@@ -742,7 +740,7 @@ class MAX_VALUE_TIME(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time")
     func: Callable = metric_funcs.max_value_time
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.MAX_VAL_TIME_ATTRS, frozen=True)
@@ -762,7 +760,7 @@ class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
     func : Callable
         The function to apply to the data, by default
         metric_funcs.annual_peak_relative_bias.
-    input_field_names : Union[List[str], JoinedTimeseriesFields]
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
         The input field names, by default
         ["primary_value", "secondary_value", "value_time"].
     attrs : Dict
@@ -773,7 +771,7 @@ class ANNUAL_PEAK_RBIAS(MetricsBasemodel):
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="annual_peak_flow_bias")
     func: Callable = metric_funcs.annual_peak_relative_bias
-    input_field_names: Union[List[str], JoinedTimeseriesFields] = Field(
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
     attrs: Dict = Field(default=tma.ANNUAL_PEAK_RBIAS_ATTRS, frozen=True)

--- a/src/teehr/querying/metric_format.py
+++ b/src/teehr/querying/metric_format.py
@@ -8,7 +8,7 @@ from pyspark.sql.functions import pandas_udf
 from pyspark.sql import types as T
 
 from teehr.models.metrics.metric_models import MetricsBasemodel
-from teehr.querying.utils import validate_fields_exist
+from teehr.querying.utils import validate_fields_exist, parse_fields_to_list
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,8 @@ def apply_aggregation_metrics(
     func_list = []
     for model in include_metrics:
 
-        validate_fields_exist(gp._df.columns, model.input_field_names)
+        input_field_names = parse_fields_to_list(model.input_field_names)
+        validate_fields_exist(gp._df.columns, input_field_names)
 
         alias = model.output_field_name
 
@@ -49,14 +50,14 @@ def apply_aggregation_metrics(
                 return_type
             )
             if (model.bootstrap.include_value_time) and \
-               ("value_time" not in model.input_field_names):
-                model.input_field_names.append("value_time")
+               ("value_time" not in input_field_names):
+                input_field_names.append("value_time")
         else:
             logger.debug(f"Applying metric: {alias}")
             func_pd = pandas_udf(model.func, model.attrs["return_type"])
 
         func_list.append(
-            func_pd(*model.input_field_names).alias(alias)
+            func_pd(*input_field_names).alias(alias)
         )
 
         # Collect the metric attributes here and attach them to the DataFrame?

--- a/tests/test_get_metrics_query.py
+++ b/tests/test_get_metrics_query.py
@@ -331,7 +331,7 @@ def test_metric_chaining(tmpdir):
         group_by=["primary_location_id"],
         include_metrics=[
             Metrics.Average(
-                input_field_names=["relative_bias"],
+                input_field_names="relative_bias",
                 output_field_name="primary_average"
             )
         ]


### PR DESCRIPTION
* Allows metric `model.input_field_names` to accept `Union[str, StrEnum, List[Union[str, StrEnum]]]`
* Adds `parse_fields_to_list(model.input_field_names)` to `apply_aggregation_metrics()`
* Enforces valid metric model fields names using `extra='forbid'` in `MetricsBasemodel`
* Allows for `seed=None` in metric bootstrap models