### PR TITLE
Updated accessor to consider reference time in timeseries plotting.

### DIFF
--- a/src/teehr/examples/07-2_site_plotting.ipynb
+++ b/src/teehr/examples/07-2_site_plotting.ipynb
@@ -60,6 +60,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# plot with no input arguments and no save path -- should just show figure\n",
     "df.teehr.timeseries_plot()"
    ]

--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -217,21 +217,21 @@ class TEEHRDataFrameAccessor:
         """Format timeseries plot."""
         # x-axis
         plot.xaxis.major_label_orientation = pi/4
-        plot.xaxis.axis_label_text_font_size = '14pt'
+        # plot.xaxis.axis_label_text_font_size = '14pt'
         plot.xaxis.axis_label_text_font_style = 'bold'
-        plot.xaxis.major_label_text_font_size = '12pt'
+        # plot.xaxis.major_label_text_font_size = '12pt'
 
         # y-axis
-        plot.yaxis.axis_label_text_font_size = '14pt'
+        # plot.yaxis.axis_label_text_font_size = '14pt'
         plot.yaxis.axis_label_text_font_style = 'bold'
-        plot.yaxis.major_label_text_font_size = '12pt'
+        # plot.yaxis.major_label_text_font_size = '12pt'
 
         # title
         plot.title.text_font_size = '12pt'
 
         # legend
         plot.legend.location = 'top_right'
-        plot.legend.label_text_font_size = '14pt'
+        # plot.legend.label_text_font_size = '14pt'
         plot.legend.border_line_width = 1
         plot.legend.border_line_color = 'black'
         plot.legend.border_line_alpha = 1.0

--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -31,14 +31,19 @@ class TEEHRDataFrameAccessor:
 
     def __init__(self, pandas_obj):
         """Initialize the class."""
+        logger.info("Initializing new dataframe_accessor object...")
         if not (isinstance(pandas_obj, gpd.GeoDataFrame)):
+            logger.info("Adding DataFrame to accessor object.")
             self._df = pandas_obj
             self._gdf = None
             self._validate(self=self, obj=pandas_obj)
+            logger.info("Object validation successful.")
         else:
+            logger.info("Adding GeoDataFrame to accessor object. ")
             self._df = None
             self._gdf = pandas_obj
             self._validate(self=self, obj=pandas_obj)
+            logger.info("Object validation successful.")
 
     @staticmethod
     def _validate(self, obj):
@@ -163,8 +168,11 @@ class TEEHRDataFrameAccessor:
         for variable in unique_variables:
             variable_df = self._df[self._df['variable_name'] == variable]
             unique_column_vals = self._timeseries_unique_values(variable_df)
-            all_list = [unique_column_vals['configuration_name'],
-                        unique_column_vals['location_id']]
+            all_list = [
+                unique_column_vals['configuration_name'],
+                unique_column_vals['location_id'],
+                unique_column_vals['reference_time']
+                ]
             res = list(itertools.product(*all_list))
             raw_schema[variable] = res
 
@@ -174,17 +182,30 @@ class TEEHRDataFrameAccessor:
             invalid_combos_count = 0
             var_df = self._df[self._df['variable_name'] == variable]
             for combo in raw_schema[variable]:
-                temp = var_df[(var_df['configuration_name'] == combo[0]) &
-                              (var_df['location_id'] == combo[1])]
-                if not temp.empty:
-                    valid_combos.append(combo)
-                else:
-                    invalid_combos_count += 1
+                if pd.isnull(combo[2]):  # reference_time is null
+                    temp = var_df[
+                        (var_df['configuration_name'] == combo[0]) &
+                        (var_df['location_id'] == combo[1])
+                        ]
+                    if not temp.empty:
+                        valid_combos.append(combo)
+                    else:
+                        invalid_combos_count += 1
+                else:  # reference_time is not null
+                    temp = var_df[
+                        (var_df['configuration_name'] == combo[0]) &
+                        (var_df['location_id'] == combo[1]) &
+                        (var_df['reference_time'] == combo[2])
+                        ]
+                    if not temp.empty:
+                        valid_combos.append(combo)
+                    else:
+                        invalid_combos_count += 1
             filtered_schema[variable] = valid_combos
             if invalid_combos_count > 0:
                 logger.info(f"""
-                    Removed {invalid_combos_count} invalid combinations from
-                    the schema.
+                    Removed {invalid_combos_count} invalid combinations
+                    from the schema.
                 """)
 
         return filtered_schema
@@ -248,20 +269,45 @@ class TEEHRDataFrameAccessor:
 
         # add data to plot
         for combo in schema[variable]:
-            logger.info(f"Processing combination: {combo}")
-            temp = df[(df['configuration_name'] == combo[0]) &
-                      (df['location_id'] == combo[1])]
-            if not temp.empty:
-                logger.info(f"Plotting data for combination: {combo}")
-                p.line(
-                    temp.value_time,
-                    temp.value,
-                    legend_label=f"{combo[0]} - {combo[1]}",
-                    line_width=1,
-                    color=next(palette)
-                )
-            else:
-                logger.warning(f"No data for combination: {combo}")
+            if pd.isnull(combo[2]):  # reference_time is null
+                logger.info(f"Processing combination: {combo}")
+                logger.info(f"""
+                            reference_time == NaT, ignoring reference_time for
+                            combo: {combo}
+                            """)
+                temp = df[
+                    (df['configuration_name'] == combo[0]) &
+                    (df['location_id'] == combo[1])
+                    ]
+                if not temp.empty:
+                    logger.info(f"Plotting data for combination: {combo}")
+                    p.line(
+                        temp.value_time,
+                        temp.value,
+                        legend_label=f"{combo[0]} - {combo[1]}",
+                        line_width=1,
+                        color=next(palette)
+                    )
+                else:
+                    logger.warning(f"No data for combination: {combo}")
+            else:  # reference_time is not null
+                logger.info(f"Processing combination: {combo}")
+                temp = df[
+                    (df['configuration_name'] == combo[0]) &
+                    (df['location_id'] == combo[1]) &
+                    (df['reference_time'] == combo[2])
+                    ]
+                if not temp.empty:
+                    logger.info(f"Plotting data for combination: {combo}")
+                    p.line(
+                        temp.value_time,
+                        temp.value,
+                        legend_label=f"{combo[0]} - {combo[1]} - {combo[2]}",
+                        line_width=1,
+                        color=next(palette)
+                    )
+                else:
+                    logger.warning(f"No data for combination: {combo}")
 
         # format plot
         p = self._timeseries_format_plot(plot=p)

--- a/tests/test_dataframe_accessor.py
+++ b/tests/test_dataframe_accessor.py
@@ -21,7 +21,11 @@ def sample_dataframe():
         'unit_name': ['unit1', 'unit1', 'unit2', 'unit2'],
         'value_time': pd.date_range(start='1/1/2022', periods=4, freq='D'),
         'value': [10, 20, 30, 40],
-        'reference_time': [None, None, None, None]
+        'reference_time': [
+            pd.Timestamp('2022-01-01'),
+            pd.Timestamp('2022-01-01'),
+            pd.Timestamp('2022-01-02'),
+            pd.NaT]
     }
     df = pd.DataFrame(data)
     df.attrs['table_type'] = 'timeseries'
@@ -116,7 +120,11 @@ def test_get_unique_values(sample_dataframe):
         'unit_name': ['unit1', 'unit2'],
         'value_time': list(sample_dataframe['value_time'].unique()),
         'value': [10, 20, 30, 40],
-        'reference_time': [None]
+        'reference_time': [
+            pd.Timestamp('2022-01-01'),
+            pd.Timestamp('2022-01-02'),
+            pd.NaT
+            ]
     }
     assert unique_values == expected_values
 
@@ -126,8 +134,15 @@ def test_timeseries_schema(sample_dataframe):
     accessor = sample_dataframe.teehr
     schema = accessor._timeseries_schema()
     expected_schema = {
-        'var1': [('config1', 1), ('config2', 2)],
-        'var2': [('config1', 1), ('config2', 2)]
+        'var1': [
+            ('config1', 1, pd.Timestamp('2022-01-01')),
+            ('config2', 2, pd.Timestamp('2022-01-01'))
+            ],
+        'var2': [
+         ('config1', 1, pd.Timestamp('2022-01-02')),
+         ('config1', 1, pd.NaT),
+         ('config2', 2, pd.NaT)
+         ]
     }
     assert schema == expected_schema
 


### PR DESCRIPTION
- updated '_timeseries_schema()' to consider reference_time when generating unique plotting combinations. Unique plotting combinations only consider reference_time if value is not null (pd.NaT).

- updated '_timeseries_generate_plot()' to consider reference time when plotting each unique plotting combination. Filtering of data via unique plotting combination only considers reference_time if value is not null (pd.NaT). Legend entries only consider reference_time if value is not null (pd.NaT). 

- updated 'test_dataframe_accessor.py' to consider both null and valid reference times.  