### PR TITLE
Add subset capability to clone_from_s3

### DIFF
--- a/src/teehr/evaluation/evaluation.py
+++ b/src/teehr/evaluation/evaluation.py
@@ -1,5 +1,6 @@
 """Evaluation module."""
-from typing import Union, Literal
+from datetime import datetime
+from typing import Union, Literal, List
 from pathlib import Path
 from pyspark.sql import SparkSession
 from pyspark import SparkConf
@@ -220,16 +221,33 @@ class Evaluation:
         """
         return list_s3_evaluations(format=format)
 
-    def clone_from_s3(self, evaluation_name: str):
+    def clone_from_s3(
+        self,
+        evaluation_name: str,
+        primary_location_ids: List[str] = None,
+        start_date: Union[str, datetime] = None,
+        end_date: Union[str, datetime] = None,
+    ):
         """Fetch the study data from S3.
 
-        Copies the study from s3 to the local directory.
+        Copies the study from s3 to the local directory, with the option
+        to subset the dataset by primary location ID, start and end dates.
 
         Parameters
         ----------
         evaluation_name : str
             The name of the evaluation to clone from S3.
-            Use the list_s3_evaluations method to get the available evaluations.
+            Use the list_s3_evaluations method to get the available
+            evaluations.
+        primary_location_ids : List[str], optional
+            The list of primary location ids to subset the data.
+            The default is None.
+        start_date : Union[str, datetime], optional
+            The start date to subset the data.
+            The default is None.
+        end_date : Union[str, datetime], optional
+            The end date to subset the data.
+            The default is None.
 
         Notes
         -----
@@ -249,7 +267,13 @@ class Evaluation:
         Also includes the user_defined_fields.py script.
 
         """
-        return clone_from_s3(self, evaluation_name)
+        return clone_from_s3(
+            self,
+            evaluation_name,
+            primary_location_ids,
+            start_date,
+            end_date
+        )
 
     def clean_cache(self):
         """Clean temporary files.

--- a/src/teehr/loading/s3/clone_from_s3.py
+++ b/src/teehr/loading/s3/clone_from_s3.py
@@ -1,10 +1,13 @@
+"""A module for cloning and optionally subsetting evaluations from s3."""
 from pathlib import Path
 import yaml
 import fsspec
 import pandas as pd
 import teehr.const as const
-from typing import Union, Literal
+from datetime import datetime
+from typing import Union, Literal, List
 import logging
+import pyspark
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +37,63 @@ def list_s3_evaluations(
     return yaml_dict["evaluations"]
 
 
-def clone_from_s3(ev, evaluation_name: str):
+def subset_the_table(
+    ev,
+    s3_dataset_path: str,
+    sdf_in: pyspark.sql.DataFrame,
+    name: str,
+    primary_location_ids: Union[None, List[str]],
+    start_date: Union[str, datetime, None],
+    end_date: Union[str, datetime, None],
+) -> pyspark.sql.DataFrame:
+    """Subset the dataset based on location and start/end time."""
+    if name == "locations" and primary_location_ids is not None:
+        sdf_in = sdf_in.filter(sdf_in.id.isin(primary_location_ids))
+    elif name == "location_attributes" and primary_location_ids is not None:
+        sdf_in = sdf_in.filter(sdf_in.location_id.isin(primary_location_ids))
+    elif name == "location_crosswalks" and primary_location_ids is not None:
+        sdf_in = sdf_in.filter(
+            sdf_in.primary_location_id.isin(primary_location_ids)
+        )
+    elif name == "primary_timeseries":
+        if primary_location_ids is not None:
+            sdf_in = sdf_in.filter(
+                sdf_in.location_id.isin(primary_location_ids)
+            )
+    elif name == "secondary_timeseries":
+        xwalk = (
+            ev.
+            spark.
+            read.
+            format("parquet").
+            load(f"{s3_dataset_path}/location_crosswalks/")
+        )
+        secondary_ids = xwalk.filter(
+            xwalk.primary_location_id.isin(primary_location_ids)
+        ).select("secondary_location_id").rdd.flatMap(lambda x: x).collect()
+        if primary_location_ids is not None:
+            sdf_in = sdf_in.filter(sdf_in.location_id.isin(secondary_ids))
+    elif name == "joined_timeseries":
+        if primary_location_ids is not None:
+            sdf_in = sdf_in.filter(
+                sdf_in.location_id.isin(primary_location_ids)
+            )
+    if "timeseries" in name:
+        if start_date is not None:
+            sdf_in = sdf_in.filter(sdf_in.value_time >= start_date)
+        if end_date is not None:
+            sdf_in = sdf_in.filter(sdf_in.value_time <= end_date)
+
+    return sdf_in
+
+
+def clone_from_s3(
+    ev,
+    evaluation_name: str,
+    primary_location_ids: Union[None, List[str]],
+    start_date: Union[str, datetime, None],
+    end_date: Union[str, datetime, None],
+):
     """Clone an evaluation from s3.
 
     Copies the evaluation from s3 to the local directory.
@@ -148,6 +207,16 @@ def clone_from_s3(ev, evaluation_name: str):
             .load(f"{s3_dataset_path}/{dir_name}/")
         )
 
+        sdf_in = subset_the_table(
+            ev=ev,
+            s3_dataset_path=s3_dataset_path,
+            sdf_in=sdf_in,
+            name=name,
+            primary_location_ids=primary_location_ids,
+            start_date=start_date,
+            end_date=end_date
+        )
+
         (
             sdf_in
             .write
@@ -156,7 +225,7 @@ def clone_from_s3(ev, evaluation_name: str):
             .save(str(local_path))
         )
 
-    # copy scriopts path to ev.scripts_dir
+    # copy scripts path to ev.scripts_dir
     source = f"{url}/scripts/user_defined_fields.py"
     dest = f"{ev.scripts_dir}/user_defined_fields.py"
     logger.debug(f"Copying from {source}/ to {dest}")

--- a/src/teehr/loading/s3/clone_from_s3.py
+++ b/src/teehr/loading/s3/clone_from_s3.py
@@ -61,17 +61,17 @@ def subset_the_table(
                 sdf_in.location_id.isin(primary_location_ids)
             )
     elif name == "secondary_timeseries":
-        xwalk = (
-            ev.
-            spark.
-            read.
-            format("parquet").
-            load(f"{s3_dataset_path}/location_crosswalks/")
-        )
-        secondary_ids = xwalk.filter(
-            xwalk.primary_location_id.isin(primary_location_ids)
-        ).select("secondary_location_id").rdd.flatMap(lambda x: x).collect()
         if primary_location_ids is not None:
+            xwalk = (
+                ev.
+                spark.
+                read.
+                format("parquet").
+                load(f"{s3_dataset_path}/location_crosswalks/")
+            )
+            secondary_ids = xwalk.filter(
+                xwalk.primary_location_id.isin(primary_location_ids)
+            ).select("secondary_location_id").rdd.flatMap(lambda x: x).collect()
             sdf_in = sdf_in.filter(sdf_in.location_id.isin(secondary_ids))
     elif name == "joined_timeseries":
         if primary_location_ids is not None:

--- a/tests/test_clone_from_s3.py
+++ b/tests/test_clone_from_s3.py
@@ -1,3 +1,4 @@
+"""Test the clone_from_s3 module."""
 import tempfile
 import pandas as pd
 from pathlib import Path
@@ -5,11 +6,13 @@ from teehr import Evaluation
 
 from teehr.loading.s3.clone_from_s3 import list_s3_evaluations
 
+
 def test_get_s3_evaluations_dataframe():
     """Test get_s3_evaluations as a dataframe."""
     df = list_s3_evaluations()
     assert len(df) == 4
     assert isinstance(df, pd.DataFrame)
+
 
 def test_get_s3_evaluations_list():
     """Test get_s3_evaluations as a list."""
@@ -18,7 +21,7 @@ def test_get_s3_evaluations_list():
     assert isinstance(l, list)
 
 
-def test_clone_example_form_s3(tmpdir):
+def test_clone_example_from_s3(tmpdir):
     """Test filter string."""
     ev = Evaluation(tmpdir)
     ev.clone_from_s3("p0_2_location_example")
@@ -37,6 +40,33 @@ def test_clone_example_form_s3(tmpdir):
     assert Path(ev.scripts_dir, "user_defined_fields.py").is_file()
 
 
+def test_clone_and_subset_example_from_s3(tmpdir):
+    """Test filter string."""
+    ev = Evaluation(tmpdir)
+    ev.clone_from_s3(
+        evaluation_name="p0_2_location_example",
+        primary_location_ids=["usgs-14316700"],
+        start_date="2001-09-30 20:00",
+        end_date="2010-09-29 20:00"
+    )
+
+    assert ev.units.to_sdf().count() == 4
+    assert ev.variables.to_sdf().count() == 3
+    assert ev.attributes.to_sdf().count() == 26
+    assert ev.configurations.to_sdf().count() == 161
+    assert ev.locations.to_sdf().count() == 1
+    assert ev.location_attributes.to_sdf().count() == 25
+    assert ev.location_crosswalks.to_sdf().count() == 1
+    assert ev.primary_timeseries.to_sdf().count() == 74433
+    assert ev.secondary_timeseries.to_sdf().count() == 78865
+    assert ev.joined_timeseries.to_sdf().count() == 74433
+    assert ev.joined_timeseries.to_pandas().value_time.max() == \
+        pd.Timestamp("2010-09-29 20:00:00")
+    assert ev.joined_timeseries.to_pandas().value_time.min() == \
+        pd.Timestamp("2001-09-30 20:00:00")
+    assert Path(ev.scripts_dir, "user_defined_fields.py").is_file()
+
+
 if __name__ == "__main__":
     test_get_s3_evaluations_dataframe()
     test_get_s3_evaluations_list()
@@ -44,7 +74,17 @@ if __name__ == "__main__":
     with tempfile.TemporaryDirectory(
         prefix="teehr-"
     ) as tempdir:
-        test_clone_example_form_s3(
+        test_clone_example_from_s3(
+            tempfile.mkdtemp(
+                prefix="1-",
+                dir=tempdir
+            )
+        )
+
+    with tempfile.TemporaryDirectory(
+        prefix="teehr-"
+    ) as tempdir:
+        test_clone_and_subset_example_from_s3(
             tempfile.mkdtemp(
                 prefix="1-",
                 dir=tempdir


### PR DESCRIPTION
Adds the ability to subset an evaluation dataset by primary location IDs, start date, and end date, when cloning from s3.

Notes:
* Currently only considers `value_time` when sub-setting by time (reference time is ignored)
* Requires that the location ID prefix is included in the `primary_location_ids` input argument
* The `subset_the_table()` function will probably need to be refactored at some point, let me know what you think, definitely open to comments