### PR TITLE
326 add example data module

### DIFF
--- a/docs/sphinx/user_guide/notebooks/01_introduction_schema.ipynb
+++ b/docs/sphinx/user_guide/notebooks/01_introduction_schema.ipynb
@@ -34,6 +34,7 @@
    "outputs": [],
    "source": [
     "import teehr\n",
+    "from teehr.evaluation.utils import print_tree\n",
     "import shutil\n",
     "from pathlib import Path\n",
     "\n",
@@ -64,9 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from teehr.evaluation.utils import print_tree\n",
-    "# print_tree(ev.dir_path)\n",
-    "!tree $HOME/temp/01_introduction_schema -L 1"
+    "print_tree(ev.dir_path, max_depth=1)"
    ]
   },
   {
@@ -96,9 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from teehr.evaluation.utils import print_tree\n",
-    "# print_tree(ev.dataset_dir)\n",
-    "!tree $HOME/temp/01_introduction_schema/dataset -L 1"
+    "print_tree(ev.dataset_dir, max_depth=0)"
    ]
   },
   {

--- a/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
+++ b/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
@@ -24,6 +24,7 @@
    "outputs": [],
    "source": [
     "import teehr\n",
+    "import teehr.example_data.v0_3_test_study as test_study_data\n",
     "from pathlib import Path\n",
     "import shutil\n",
     "import geopandas as gpd\n",
@@ -80,8 +81,8 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/geo/gages.geojson \\\n",
-    "    -O $HOME/temp/02_loading_data/gages.geojson"
+    "location_data_path = Path(test_eval_dir, \"gages.geojson\")\n",
+    "test_study_data.fetch_file(\"gages.geojson\", location_data_path)"
    ]
   },
   {
@@ -177,8 +178,8 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/timeseries/test_short_obs.csv \\\n",
-    "    -O $HOME/temp/02_loading_data/test_short_obs.csv"
+    "primary_timeseries_path = Path(test_eval_dir, \"test_short_obs.csv\")\n",
+    "test_study_data.fetch_file(\"test_short_obs.csv\", primary_timeseries_path)"
    ]
   },
   {
@@ -187,8 +188,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Open the primary timeseries file and inspect the first few rows\n",
-    "primary_timeseries_path = Path(test_eval_dir, \"test_short_obs.csv\")\n",
     "primary_timeseries_df = pd.read_csv(primary_timeseries_path)\n",
     "primary_timeseries_df.head()"
    ]
@@ -342,9 +341,8 @@
    },
    "outputs": [],
    "source": [
-    "\n",
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/timeseries/test_short_fcast.parquet \\\n",
-    "    -O $HOME/temp/02_loading_data/test_short_fcast.parquet\n"
+    "secondary_timeseries_path = Path(test_eval_dir, \"test_short_fcast.parquet\")\n",
+    "test_study_data.fetch_file(\"test_short_fcast.parquet\", secondary_timeseries_path)\n"
    ]
   },
   {
@@ -360,7 +358,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "secondary_timeseries_path = Path(test_eval_dir, \"test_short_fcast.parquet\")\n",
     "secondary_timeseries_df = pd.read_parquet(secondary_timeseries_path)\n",
     "secondary_timeseries_df.head()"
    ]
@@ -407,8 +404,8 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/geo/crosswalk.csv \\\n",
-    "    -O $HOME/temp/02_loading_data/crosswalk.csv"
+    "crosswalk_path = Path(test_eval_dir, \"crosswalk.csv\")\n",
+    "test_study_data.fetch_file(\"crosswalk.csv\", crosswalk_path)"
    ]
   },
   {
@@ -417,7 +414,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crosswalk_path = Path(test_eval_dir, \"crosswalk.csv\")\n",
     "crosswalk_df = pd.read_csv(crosswalk_path)\n",
     "crosswalk_df"
    ]
@@ -531,14 +527,14 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/geo/test_attr_2yr_discharge.csv \\\n",
-    "    -O $HOME/temp/02_loading_data/test_attr_2yr_discharge.csv\n",
+    "attr_2yr_discharge_df = pd.read_csv(Path(test_eval_dir, \"test_attr_2yr_discharge.csv\"))\n",
+    "test_study_data.fetch_file(\"test_attr_2yr_discharge.csv\", Path(test_eval_dir, \"test_attr_2yr_discharge.csv\"))\n",
     "\n",
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/geo/test_attr_drainage_area_km2.csv \\\n",
-    "    -O $HOME/temp/02_loading_data/test_attr_drainage_area_km2.csv\n",
+    "attr_drainage_area_km2_df = pd.read_csv(Path(test_eval_dir, \"test_attr_drainage_area_km2.csv\"))\n",
+    "test_study_data.fetch_file(\"test_attr_drainage_area_km2.csv\", Path(test_eval_dir, \"test_attr_drainage_area_km2.csv\"))\n",
     "\n",
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/v0.4-beta/tests/data/v0_3_test_study/geo/test_attr_ecoregion.csv \\\n",
-    "    -O $HOME/temp/02_loading_data/test_attr_ecoregion.csv"
+    "attr_ecoregion_df = pd.read_csv(Path(test_eval_dir, \"test_attr_ecoregion.csv\"))\n",
+    "test_study_data.fetch_file(\"test_attr_ecoregion.csv\", Path(test_eval_dir, \"test_attr_ecoregion.csv\"))"
    ]
   },
   {

--- a/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
+++ b/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
@@ -527,14 +527,14 @@
    },
    "outputs": [],
    "source": [
-    "attr_2yr_discharge_df = pd.read_csv(Path(test_eval_dir, \"test_attr_2yr_discharge.csv\"))\n",
-    "test_study_data.fetch_file(\"test_attr_2yr_discharge.csv\", Path(test_eval_dir, \"test_attr_2yr_discharge.csv\"))\n",
+    "attr_2yr_discharge_path = Path(test_eval_dir, \"test_attr_2yr_discharge.csv\")\n",
+    "test_study_data.fetch_file(\"test_attr_2yr_discharge.csv\", attr_2yr_discharge_path)\n",
     "\n",
-    "attr_drainage_area_km2_df = pd.read_csv(Path(test_eval_dir, \"test_attr_drainage_area_km2.csv\"))\n",
-    "test_study_data.fetch_file(\"test_attr_drainage_area_km2.csv\", Path(test_eval_dir, \"test_attr_drainage_area_km2.csv\"))\n",
+    "attr_drainage_area_km2_path = Path(test_eval_dir, \"test_attr_drainage_area_km2.csv\")\n",
+    "test_study_data.fetch_file(\"test_attr_drainage_area_km2.csv\", attr_drainage_area_km2_path)\n",
     "\n",
-    "attr_ecoregion_df = pd.read_csv(Path(test_eval_dir, \"test_attr_ecoregion.csv\"))\n",
-    "test_study_data.fetch_file(\"test_attr_ecoregion.csv\", Path(test_eval_dir, \"test_attr_ecoregion.csv\"))"
+    "attr_ecoregion_path = Path(test_eval_dir, \"test_attr_ecoregion.csv\")\n",
+    "test_study_data.fetch_file(\"test_attr_ecoregion.csv\", attr_ecoregion_path)"
    ]
   },
   {

--- a/docs/sphinx/user_guide/notebooks/03_introduction_class.ipynb
+++ b/docs/sphinx/user_guide/notebooks/03_introduction_class.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "import teehr\n",
+    "from teehr.evaluation.utils import print_tree\n",
     "from pathlib import Path\n",
     "\n",
     "# Define the directory where the Evaluation will be created\n",
@@ -59,10 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from teehr.evaluation.utils import print_tree\n",
-    "# print_tree(ev.dataset_dir, exclude_patterns=[\".*\", \"_*\"])\n",
-    "\n",
-    "!tree $HOME/temp/02_loading_data/dataset -I \".*|_*\""
+    "print_tree(ev.dataset_dir, exclude_patterns=[\".*\", \"_*\"])"
    ]
   },
   {

--- a/docs/sphinx/user_guide/notebooks/04_setup_simple_example.ipynb
+++ b/docs/sphinx/user_guide/notebooks/04_setup_simple_example.ipynb
@@ -30,6 +30,7 @@
    "outputs": [],
    "source": [
     "import teehr\n",
+    "import teehr.example_data.two_locations as two_locations_data\n",
     "import pandas as pd\n",
     "import geopandas as gpd\n",
     "from pathlib import Path\n",
@@ -78,11 +79,12 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/two_locations/two_locations.parquet \\\n",
-    "    -O $HOME/temp/04_setup_real_example/two_locations.parquet\n",
+    "location_data_path = Path(test_eval_dir, \"two_locations.parquet\")\n",
+    "two_locations_data.fetch_file(\"two_locations.parquet\", location_data_path)\n",
     "\n",
-    "!wget https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/two_locations/two_crosswalks.parquet \\\n",
-    "    -O $HOME/temp/04_setup_real_example/two_crosswalks.parquet"
+    "crosswalk_data_path = Path(test_eval_dir, \"two_crosswalks.parquet\")\n",
+    "two_locations_data.fetch_file(\"two_crosswalks.parquet\", crosswalk_data_path)\n",
+    "\n"
    ]
   },
   {
@@ -99,7 +101,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "location_data_path = Path(test_eval_dir, \"two_locations.parquet\")\n",
     "gdf = gpd.read_parquet(location_data_path)\n",
     "gdf"
    ]

--- a/src/teehr/evaluation/utils.py
+++ b/src/teehr/evaluation/utils.py
@@ -15,9 +15,23 @@ def get_schema_variable_name(variable_name: str) -> str:
     return NWM_VARIABLE_MAPPER[VARIABLE_NAME]. \
         get(variable_name, variable_name)
 
+PIPE = "│"
+ELBOW = "└──"
+TEE = "├──"
+PIPE_PREFIX = "│   "
+SPACE_PREFIX = "    "
 
-def print_tree(path, prefix="", exclude_patterns: List[str] = [""]):
+def print_tree(
+    path,
+    prefix="",
+    exclude_patterns: List[str] = [""],
+    max_depth: int = -1,
+    current_depth: int = 0
+):
     """Print the directory tree structure."""
+
+    if max_depth != -1 and current_depth > max_depth:
+        return
 
     # Get all files and directories in the current path
     paths = list(Path(path).glob("*"))
@@ -26,10 +40,21 @@ def print_tree(path, prefix="", exclude_patterns: List[str] = [""]):
     filtered_files = [f for f in paths if not any(fnmatch.fnmatch(f.name, p) for p in exclude_patterns)]
 
     # Print the directory tree structure
-    for full_path in filtered_files:
+    entries_count = len(filtered_files)
+
+    for index, full_path in enumerate(filtered_files):
         name = full_path.relative_to(path)
+        connector = ELBOW if index == entries_count - 1 else TEE
+
         if full_path.is_dir():
-            print(f"{prefix}├── {name}")
-            print_tree(path=full_path, prefix=f"{prefix}│   ", exclude_patterns=exclude_patterns)
+            print(f"{prefix}{connector} {name}")
+            new_prefix = prefix + (PIPE_PREFIX if index != entries_count - 1 else SPACE_PREFIX)
+            print_tree(
+                path=full_path,
+                prefix=new_prefix,
+                exclude_patterns=exclude_patterns,
+                max_depth=max_depth,
+                current_depth=current_depth + 1
+            )
         else:
-            print(f"{prefix}├── {name}")
+            print(f"{prefix}{connector} {name}")

--- a/src/teehr/example_data/two_locations.py
+++ b/src/teehr/example_data/two_locations.py
@@ -1,0 +1,39 @@
+"""Module to fetch test data."""
+
+import requests
+
+
+files = [
+    {
+        "name": "two_crosswalks.parquet",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/two_locations/two_crosswalks.parquet"
+    },
+    {
+        "name": "two_location_attributes.parquet",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/two_locations/two_location_attributes.parquet"
+    },
+    {
+        "name": "two_locations.parquet",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/two_locations/two_locations.parquet"
+    }
+]
+
+def fetch_and_save_file(url: str, destination: str) -> None:
+    """Fetch a file from a URL and save it to a destination."""
+    response = requests.get(url)
+    response.raise_for_status()  # Ensure we notice bad responses
+
+    with open(destination, 'wb') as f:
+        f.write(response.content)
+
+
+def list_files() -> list:
+    return [file["name"] for file in files]
+
+
+def fetch_file(file_name: str, destination: str) -> None:
+    """Fetch a file by name."""
+    file = next(file for file in files if file["name"] == file_name)
+    fetch_and_save_file(file["url"], destination)
+
+

--- a/src/teehr/example_data/v0_3_test_study.py
+++ b/src/teehr/example_data/v0_3_test_study.py
@@ -1,0 +1,55 @@
+"""Module to fetch test data."""
+
+import requests
+
+
+files = [
+    {
+        "name": "gages.geojson",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/geo/gages.geojson"
+    },
+    {
+        "name": "test_short_obs.csv",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/timeseries/test_short_obs.csv"
+    },
+    {
+        "name": "test_short_fcast.parquet",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/timeseries/test_short_fcast.parquet"
+    },
+    {
+        "name": "crosswalk.csv",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/geo/crosswalk.csv"
+    },
+    {
+        "name": "test_attr_2yr_discharge.csv",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/geo/test_attr_2yr_discharge.csv"
+    },
+    {
+        "name": "test_attr_drainage_area_km2.csv",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/geo/test_attr_drainage_area_km2.csv"
+    },
+    {
+        "name": "test_attr_ecoregion.csv",
+        "url": "https://github.com/RTIInternational/teehr/raw/refs/heads/main/tests/data/v0_3_test_study/geo/test_attr_ecoregion.csv"
+    }
+]
+
+def fetch_and_save_file(url: str, destination: str) -> None:
+    """Fetch a file from a URL and save it to a destination."""
+    response = requests.get(url)
+    response.raise_for_status()  # Ensure we notice bad responses
+
+    with open(destination, 'wb') as f:
+        f.write(response.content)
+
+
+def list_files() -> list:
+    return [file["name"] for file in files]
+
+
+def fetch_file(file_name: str, destination: str) -> None:
+    """Fetch a file by name."""
+    file = next(file for file in files if file["name"] == file_name)
+    fetch_and_save_file(file["url"], destination)
+
+


### PR DESCRIPTION
Removes CLI call in notebooks that don't work across platforms, Windows, etc.

- Adds an example data module and switches use guide notebooks to it instead of `wget`.
- Switches to TEEHR print_tree instead of `tree` CLI.