### PR TITLE
Updating grouping and joining tutorials

### DIFF
--- a/docs/sphinx/tutorials/tutorials_index.rst
+++ b/docs/sphinx/tutorials/tutorials_index.rst
@@ -1,9 +1,0 @@
-Tutorials
-=========
-
-
-.. toctree::
-   :maxdepth: 2
-
-   joining_timeseries
-   grouping_and_filtering

--- a/docs/sphinx/user_guide/index.rst
+++ b/docs/sphinx/user_guide/index.rst
@@ -24,7 +24,7 @@ Before starting, make sure you have installed TEEHR and its dependencies as desc
 
 :doc:`Clone an Evaluation from S3 </user_guide/notebooks/05_clone_from_s3>`  :download:`(download notebook) </user_guide/notebooks/05_clone_from_s3.ipynb>`
 
-:doc:`Grouping and Filtering <../tutorials/grouping_and_filtering>`  :download:`(download notebook) <../tutorials/grouping_and_filtering.ipynb>`
+:doc:`Grouping and Filtering </user_guide/notebooks/06_grouping_and_filtering>`  :download:`(download notebook) </user_guide/notebooks/06_grouping_and_filtering.ipynb>`
 
 
 .. toctree::
@@ -36,6 +36,6 @@ Before starting, make sure you have installed TEEHR and its dependencies as desc
    Introduction to the Evaluation Class </user_guide/notebooks/03_introduction_class>
    Setting-up a Simple Example </user_guide/notebooks/04_setup_simple_example>
    Clone an Evaluation from S3 </user_guide/notebooks/05_clone_from_s3>
-   Grouping and Filtering <../tutorials/grouping_and_filtering>
+   Joining Timeseries </user_guide/tutorials/joining_timeseries>
+   Grouping and Filtering </user_guide/notebooks/06_grouping_and_filtering>
    Metrics </user_guide/metrics/metrics>
-   Joining Timeseries <../tutorials/joining_timeseries>

--- a/docs/sphinx/user_guide/notebooks/06_grouping_and_filtering.ipynb
+++ b/docs/sphinx/user_guide/notebooks/06_grouping_and_filtering.ipynb
@@ -11,8 +11,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Note:** The images shown below are slightly out of date. We are in the process of updating them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Once the data has been joined into a single table, we can start to group and filter the data based on the table attributes,\n",
-    "and calculate metrics for specific subsets of the data.  This is the explorative power of TEEHR, and allows us to\n",
+    "and calculate metrics for specific subsets of the data.  This is the explorative power of TEEHR, which allows us to\n",
     "better understand model performance. For example, if the joined table contained several model simulations (\"configurations\")\n",
     "we could group the ``configuration_name`` field to calculate performance metrics for each model configuration.\n",
     "\n",
@@ -40,7 +47,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://github.com/RTIInternational/teehr/blob/304-update-the-grouping-and-joining-docs-for-v040/docs/images/tutorials/grouping_filtering/grouping_example_table.png?raw=true\">"
+    "<img src=\"https://github.com/RTIInternational/teehr/blob/main/docs/images/tutorials/grouping_filtering/grouping_example_table.png?raw=true\" width=\"600px\" height=\"600px\">"
    ]
   },
   {
@@ -84,34 +91,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's use this table of joined timeseries values to demonstrate how grouping selected fields affects the results.\n",
-    "\n",
-    "First, we'll calculate the relative bias for each model configuration at each location:"
+    "<img src=\"https://github.com/RTIInternational/teehr/blob/main/docs/images/tutorials/grouping_filtering/grouping_example_1.png?raw=true\" width=850 height=500>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://raw.githubusercontent.com/RTIInternational/teehr/refs/heads/304-update-the-grouping-and-joining-docs-for-v040/docs/images/tutorials/grouping_filtering/grouping_example_1.png\" width=850 height=500>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can demonstrate how this calculation is performed in TEEHR using sample data. First, we'll set up a local directory that will contain our Evaluation, then we'll clone a subset of an existing Evaluation from s3."
+    "We can demonstrate how this calculation is performed in TEEHR using sample data. First, we'll set up a local directory that will contain our Evaluation, then we'll clone a subset of an existing Evaluation from s3 storage."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "24/11/17 10:28:01 WARN Utils: Your hostname, ubuntu3 resolves to a loopback address: 127.0.1.1; using 10.0.2.15 instead (on interface enp0s3)\n",
+      "24/11/17 10:28:01 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
+      "24/11/17 10:28:01 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "24/11/17 10:28:02 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.\n"
+     ]
+    }
+   ],
    "source": [
     "from pathlib import Path\n",
     "import shutil\n",
@@ -128,9 +139,89 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>description</th>\n",
+       "      <th>url</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>p0_2_location_example</td>\n",
+       "      <td>Example evaluation datsets with 2 USGS gages</td>\n",
+       "      <td>s3a://ciroh-rti-public-data/teehr-data-warehou...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>p1_camels_daily_streamflow</td>\n",
+       "      <td>Daily average streamflow at ther Camels basins</td>\n",
+       "      <td>s3a://ciroh-rti-public-data/teehr-data-warehou...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>p2_camels_hourly_streamflow</td>\n",
+       "      <td>Hourly instantaneous streamflow at ther Camels...</td>\n",
+       "      <td>s3a://ciroh-rti-public-data/teehr-data-warehou...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>p3_usgs_hourly_streamflow</td>\n",
+       "      <td>Hourly instantaneous streamflow at USGS CONUS ...</td>\n",
+       "      <td>s3a://ciroh-rti-public-data/teehr-data-warehou...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          name  \\\n",
+       "0        p0_2_location_example   \n",
+       "1   p1_camels_daily_streamflow   \n",
+       "2  p2_camels_hourly_streamflow   \n",
+       "3    p3_usgs_hourly_streamflow   \n",
+       "\n",
+       "                                         description  \\\n",
+       "0       Example evaluation datsets with 2 USGS gages   \n",
+       "1     Daily average streamflow at ther Camels basins   \n",
+       "2  Hourly instantaneous streamflow at ther Camels...   \n",
+       "3  Hourly instantaneous streamflow at USGS CONUS ...   \n",
+       "\n",
+       "                                                 url  \n",
+       "0  s3a://ciroh-rti-public-data/teehr-data-warehou...  \n",
+       "1  s3a://ciroh-rti-public-data/teehr-data-warehou...  \n",
+       "2  s3a://ciroh-rti-public-data/teehr-data-warehou...  \n",
+       "3  s3a://ciroh-rti-public-data/teehr-data-warehou...  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# List the evaluations in the S3 bucket\n",
     "ev.list_s3_evaluations()"
@@ -138,13 +229,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "24/11/17 10:28:09 WARN MetricsConfig: Cannot locate configuration: tried hadoop-metrics2-s3a-file-system.properties,hadoop-metrics2.properties\n",
+      "24/11/17 10:28:33 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.\n",
+      "                                                                                \r"
+     ]
+    }
+   ],
    "source": [
     "ev.clone_from_s3(\n",
     "    evaluation_name=\"p1_camels_daily_streamflow\",\n",
@@ -152,6 +253,13 @@
     "    start_date=\"1990-10-30 00:00\",\n",
     "    end_date=\"1990-11-02 23:00\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we calculate relative bias, grouping by ``primary_location_id`` and ``configuration_name``:"
    ]
   },
   {
@@ -188,7 +296,7 @@
    "metadata": {},
    "source": [
     "Note that if you wanted to include a field in the query result, it must be included in the ``group_by`` list\n",
-    "even if it's not necessary for the grouping operation!\n",
+    "even if it's not necessary for the grouping operation.\n",
     "\n",
     "For example, if we wanted to include ``q95`` in the query result, we would need to include it in the\n",
     "``group_by`` list:"
@@ -198,7 +306,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://github.com/RTIInternational/teehr/blob/304-update-the-grouping-and-joining-docs-for-v040/docs/images/tutorials/grouping_filtering/grouping_example_2.png?raw=true\" width=850>"
+    "<img src=\"https://github.com/RTIInternational/teehr/blob/main/docs/images/tutorials/grouping_filtering/grouping_example_2.png?raw=true\" width=\"850px\" height=\"450px\">"
    ]
   },
   {
@@ -244,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://github.com/RTIInternational/teehr/blob/304-update-the-grouping-and-joining-docs-for-v040/docs/images/tutorials/grouping_filtering/grouping_example_3.png?raw=true\" width=850>"
+    "<img src=\"https://github.com/RTIInternational/teehr/blob/main/docs/images/tutorials/grouping_filtering/grouping_example_3.png?raw=true\" width=\"850px\" height=\"450px\">"
    ]
   },
   {

--- a/docs/sphinx/user_guide/tutorials/joining_timeseries.rst
+++ b/docs/sphinx/user_guide/tutorials/joining_timeseries.rst
@@ -3,6 +3,8 @@
 Joining Timeseries
 ==================
 
+**Note:** The schema in the images shown below are slightly out of date. We are in the process of updating them.
+
 One of the first and most important steps in comparing simulated and observed timeseries data is to join
 the two datasets together based on location and time (and potentially other fields).
 
@@ -12,7 +14,7 @@ time steps at five different locations (gage stations).
 
 When the timeseries and attributes have been brought into the TEEHR data model, it will look something like this:
 
-.. figure:: ../../images/tutorials/joining/nwm_usgs_ex_data_model.png
+.. figure:: ../../../images/tutorials/joining/nwm_usgs_ex_data_model.png
    :scale: 60%
 
    Example NWM and USGS data in the TEEHR data model.
@@ -32,7 +34,7 @@ attributes.  This requires the crosswalk table to map the primary and secondary 
 the data may contain more than one variable (e.g., temperature, C) we also need to consider the `variable_name`
 and `measurement_unit` fields during the join.
 
-.. figure:: ../../images/tutorials/joining/nwm_usgs_ex_joining_snip.png
+.. figure:: ../../../images/tutorials/joining/nwm_usgs_ex_joining_snip.png
    :scale: 55%
 
    Joining the primary and secondary streamflow values by location, time, variable name, and measurement unit.
@@ -40,7 +42,7 @@ and `measurement_unit` fields during the join.
 
 The initial joined timeseries table will look like this:
 
-.. figure:: ../../images/tutorials/joining/nwm_usgs_ex_joined.png
+.. figure:: ../../../images/tutorials/joining/nwm_usgs_ex_joined.png
    :scale: 40%
 
    Example joined timeseries table.
@@ -52,7 +54,7 @@ easily filter and group the data based on the location attributes, and to visual
 To join the geometry, we can simply map each primary location ID in the joined timeseries table to the ID in the
 geometry table, which in this case contains the point geometries of the USGS gage stations.
 
-.. figure:: ../../images/tutorials/joining/nwm_usgs_ex_joining_geometry.png
+.. figure:: ../../../images/tutorials/joining/nwm_usgs_ex_joining_geometry.png
    :scale: 55%
 
    Joining the geometry to the initial joined timeseries table.
@@ -60,7 +62,7 @@ geometry table, which in this case contains the point geometries of the USGS gag
 Finally, we can join additional, pre-calculated attributes the table, which give us more options for
 filtering and grouping the data when calculating performance metrics.
 
-.. figure:: ../../images/tutorials/joining/nwm_usgs_ex_joining_attributes.png
+.. figure:: ../../../images/tutorials/joining/nwm_usgs_ex_joining_attributes.png
    :scale: 60%
 
    Joining the attributes to the initial joined timeseries table.


### PR DESCRIPTION
This PR contains updates to the `joining_timeseries` and `grouping_and_filtering` tutorial docs:

* Fixes broken image links and some typos in grouping_and_filtering notebook
* Moves and renames `grouping_and_filtering.ipynb` to `notebooks/06_grouping_and_filtering.ipynb`
* Moves `tutorials` dir (now only contains `joining_timeseries.rst`) into `notebooks`
* Changes order of User Guide TOC to joining --> grouping --> metrics
* Removes `tutorials_index.rst`
* Adds note at top of each page about images being out of date.  I've started working on updating the images but thought we might want to get these changes in first.  Let me know what you think.
* I have not seen additional examples of grouping, but haven't been able to track down your original files. 