### PR TITLE
Updated timeseries_plot() to consider secondary_timeseries table

### DIFF
--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -278,7 +278,8 @@ class TEEHRDataFrameAccessor:
                     if pd.isnull(combo[2]):
                         temp = var_df[
                             (var_df['configuration_name'] == combo[0]) &
-                            (var_df['location_id'] == combo[1])
+                            (var_df['location_id'] == combo[1]) &
+                            (var_df['reference_time'].isnull())
                             ]
                         if not temp.empty:
                             valid_combos.append(combo)
@@ -313,7 +314,9 @@ class TEEHRDataFrameAccessor:
                     if (pd.isnull(combo[2]) and pd.isnull(combo[3])):
                         temp = var_df[
                             (var_df['configuration_name'] == combo[0]) &
-                            (var_df['location_id'] == combo[1])
+                            (var_df['location_id'] == combo[1]) &
+                            (var_df['reference_time'].isnull()) &
+                            (var_df['member'].isnull())
                             ]
                         if not temp.empty:
                             valid_combos.append(combo)
@@ -324,6 +327,7 @@ class TEEHRDataFrameAccessor:
                         temp = var_df[
                             (var_df['configuration_name'] == combo[0]) &
                             (var_df['location_id'] == combo[1]) &
+                            (var_df['reference_time'].isnull()) &
                             (var_df['member'] == combo[3])
                             ]
                         if not temp.empty:
@@ -335,7 +339,8 @@ class TEEHRDataFrameAccessor:
                         temp = var_df[
                             (var_df['configuration_name'] == combo[0]) &
                             (var_df['location_id'] == combo[1]) &
-                            (var_df['reference_time'] == combo[2])
+                            (var_df['reference_time'] == combo[2]) &
+                            (var_df['member'].isnull())
                             ]
                         if not temp.empty:
                             valid_combos.append(combo)
@@ -426,7 +431,8 @@ class TEEHRDataFrameAccessor:
                                 """)
                     temp = df[
                         (df['configuration_name'] == combo[0]) &
-                        (df['location_id'] == combo[1])
+                        (df['location_id'] == combo[1]) &
+                        (df['reference_time'].isnull())
                         ]
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
@@ -473,7 +479,9 @@ class TEEHRDataFrameAccessor:
                                 """)
                     temp = df[
                         (df['configuration_name'] == combo[0]) &
-                        (df['location_id'] == combo[1])
+                        (df['location_id'] == combo[1]) &
+                        (df['reference_time'].isnull()) &
+                        (df['member'].isnull())
                         ]
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
@@ -496,6 +504,7 @@ class TEEHRDataFrameAccessor:
                     temp = df[
                         (df['configuration_name'] == combo[0]) &
                         (df['location_id'] == combo[1]) &
+                        (df['reference_time'].isnull()) &
                         (df['member'] == combo[3])
                         ]
                     if not temp.empty:
@@ -520,7 +529,8 @@ class TEEHRDataFrameAccessor:
                     temp = df[
                         (df['configuration_name'] == combo[0]) &
                         (df['location_id'] == combo[1]) &
-                        (df['reference_time'] == combo[2])
+                        (df['reference_time'] == combo[2]) &
+                        (df['member'].isnull())
                         ]
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")

--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -185,6 +185,37 @@ class TEEHRDataFrameAccessor:
                 supported.
             """)
 
+    def _validate_path(self, output_dir):
+        """Validate the output directory path."""
+        logger.info("Validating output directory path.")
+        if not isinstance(output_dir, Path):
+            logger.info(f"""
+                        Output directory must be a pathlib.Path object.
+                        Path was provided as type: {type(output_dir)}.
+                        Attempting to convert to pathlib.Path object.
+            """)
+            try:
+                output_dir = Path(output_dir)
+                logger.info("Path conversion successful.")
+            except TypeError:
+                logger.error("Path conversion failed.")
+
+        # check for output location
+        if output_dir is not None:
+            if output_dir.exists():
+                logger.info("Specified save directory is valid.")
+            else:
+                logger.info(""""
+                    Specified directory does not exist.
+                    Creating new directory to store figure.
+                """)
+                try:
+                    Path(output_dir).mkdir(parents=True, exist_ok=True)
+                except ValueError:
+                    logger.error("Directory creation failed.")
+
+        return output_dir
+
     def _timeseries_unique_values(
         self,
         variable_df: pd.DataFrame,
@@ -607,16 +638,8 @@ class TEEHRDataFrameAccessor:
                 "secondary_timeseries", got table_type = {table_type_str}
             """)
 
-        # check for output location
-        if output_dir is not None:
-            if output_dir.exists():
-                logger.info("Specified save directory is valid.")
-            else:
-                logger.info(""""
-                    Specified directory does not exist.
-                    Creating new directory to store figure.
-                """)
-                Path(output_dir).mkdir(parents=True, exist_ok=True)
+        # validate output location
+        output_dir = self._validate_path(output_dir)
 
         # generate plots
         schema = self._timeseries_schema()
@@ -744,16 +767,8 @@ class TEEHRDataFrameAccessor:
                 got table_type = {table_type_str}
             """)
 
-        # check output location
-        if output_dir is not None:
-            if output_dir.exists():
-                logger.info("Specified save directory is valid.")
-            else:
-                logger.info("""
-                    Specified directory does not exist.
-                    Creating new directory to store figure.
-                """)
-                Path(output_dir).mkdir(parents=True, exist_ok=True)
+        # validate output location
+        output_dir = self._validate_path(output_dir)
 
         geo_data = self._location_format_points()
 
@@ -958,16 +973,8 @@ class TEEHRDataFrameAccessor:
                 got table_type = {table_type_str}
             """)
 
-        # check output location
-        if output_dir is not None:
-            if output_dir.exists():
-                logger.info("Specified save directory is valid.")
-            else:
-                logger.info("""
-                    Specified directory does not exist.
-                    Creating new directory to store figure.
-                """)
-                Path(output_dir).mkdir(parents=True, exist_ok=True)
+        # validate output location
+        output_dir = self._validate_path(output_dir)
 
         # format point data
         geo_data = self._location_attributes_format_points()
@@ -1090,16 +1097,8 @@ class TEEHRDataFrameAccessor:
                 got table_type = {table_type_str}
             """)
 
-        # check output location
-        if output_dir is not None:
-            if output_dir.exists():
-                logger.info("Specified save directory is valid.")
-            else:
-                logger.info("""
-                    Specified directory does not exist.
-                    Creating new directory to store figure.
-                """)
-                Path(output_dir).mkdir(parents=True, exist_ok=True)
+        # validate output location
+        output_dir = self._validate_path(output_dir)
 
         # assemble data
         geo_data = self._location_crosswalks_format_points()

--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -71,11 +71,18 @@ class TEEHRDataFrameAccessor:
 
         elif obj.attrs['table_type'] == 'secondary_timeseries':
 
-            #TO-DO: add validation
+            # validate using pandera schema
+            schema = schemas.secondary_timeseries_schema(type='pandas')
+            try:
+                schema.validate(obj)
+            except pa.errors.SchemaError as exc:
+                raise AttributeError(
+                    f"Pandera validation failed: {exc}"
+                )
 
-            raise NotImplementedError(
-                "Secondary_timeseries methods must be implemented."
-            )
+            # check for data
+            if obj.index.size == 0:
+                raise AttributeError("DataFrame must have data.")
 
         elif obj.attrs['table_type'] == 'joined_timeseries':
 
@@ -198,50 +205,130 @@ class TEEHRDataFrameAccessor:
         raw_schema = {}
         filtered_schema = {}
 
-        # get all unique combinations
-        for variable in unique_variables:
-            variable_df = self._df[self._df['variable_name'] == variable]
-            unique_column_vals = self._timeseries_unique_values(variable_df)
-            all_list = [
-                unique_column_vals['configuration_name'],
-                unique_column_vals['location_id'],
-                unique_column_vals['reference_time']
-                ]
-            res = list(itertools.product(*all_list))
-            raw_schema[variable] = res
+        # get all unique combinations (primary_timeseries)
+        if self._df.attrs['table_type'] == 'primary_timeseries':
+            for variable in unique_variables:
+                variable_df = self._df[self._df['variable_name'] == variable]
+                unique_column_vals = self._timeseries_unique_values(
+                    variable_df
+                    )
+                all_list = [
+                    unique_column_vals['configuration_name'],
+                    unique_column_vals['location_id'],
+                    unique_column_vals['reference_time']
+                    ]
+                res = list(itertools.product(*all_list))
+                raw_schema[variable] = res
 
-        # filter out invalid unique combinations
-        for variable in unique_variables:
-            valid_combos = []
-            invalid_combos_count = 0
-            var_df = self._df[self._df['variable_name'] == variable]
-            for combo in raw_schema[variable]:
-                if pd.isnull(combo[2]):  # reference_time is null
-                    temp = var_df[
-                        (var_df['configuration_name'] == combo[0]) &
-                        (var_df['location_id'] == combo[1])
-                        ]
-                    if not temp.empty:
-                        valid_combos.append(combo)
-                    else:
-                        invalid_combos_count += 1
-                else:  # reference_time is not null
-                    temp = var_df[
-                        (var_df['configuration_name'] == combo[0]) &
-                        (var_df['location_id'] == combo[1]) &
-                        (var_df['reference_time'] == combo[2])
-                        ]
-                    if not temp.empty:
-                        valid_combos.append(combo)
-                    else:
-                        invalid_combos_count += 1
-            filtered_schema[variable] = valid_combos
-            if invalid_combos_count > 0:
-                logger.info(f"""
-                    Removed {invalid_combos_count} invalid combinations
-                    from the schema.
-                """)
+        # get all unique combinations (secondary_timeseries)
+        else:
+            for variable in unique_variables:
+                variable_df = self._df[self._df['variable_name'] == variable]
+                unique_column_vals = self._timeseries_unique_values(
+                    variable_df
+                    )
+                all_list = [
+                    unique_column_vals['configuration_name'],
+                    unique_column_vals['location_id'],
+                    unique_column_vals['reference_time'],
+                    unique_column_vals['member']
+                    ]
+                res = list(itertools.product(*all_list))
+                raw_schema[variable] = res
 
+        # primary timeseries filter routine (no data for combo)
+        if self._df.attrs['table_type'] == 'primary_timeseries':
+            for variable in unique_variables:
+                valid_combos = []
+                invalid_combos_count = 0
+                var_df = self._df[self._df['variable_name'] == variable]
+                for combo in raw_schema[variable]:
+                    # reference_time is null
+                    if pd.isnull(combo[2]):
+                        temp = var_df[
+                            (var_df['configuration_name'] == combo[0]) &
+                            (var_df['location_id'] == combo[1])
+                            ]
+                        if not temp.empty:
+                            valid_combos.append(combo)
+                        else:
+                            invalid_combos_count += 1
+                    # reference_time is not null
+                    else:
+                        temp = var_df[
+                            (var_df['configuration_name'] == combo[0]) &
+                            (var_df['location_id'] == combo[1]) &
+                            (var_df['reference_time'] == combo[2])
+                            ]
+                        if not temp.empty:
+                            valid_combos.append(combo)
+                        else:
+                            invalid_combos_count += 1
+                filtered_schema[variable] = valid_combos
+                if invalid_combos_count > 0:
+                    logger.info(f"""
+                        Removed {invalid_combos_count} invalid combinations
+                        from the schema.
+                    """)
+
+        # secondary timeseries filter routine (no data for combo)
+        else:
+            for variable in unique_variables:
+                valid_combos = []
+                invalid_combos_count = 0
+                var_df = self._df[self._df['variable_name'] == variable]
+                for combo in raw_schema[variable]:
+                    # reference_time is null, member is null
+                    if (pd.isnull(combo[2]) and pd.isnull(combo[3])):
+                        temp = var_df[
+                            (var_df['configuration_name'] == combo[0]) &
+                            (var_df['location_id'] == combo[1])
+                            ]
+                        if not temp.empty:
+                            valid_combos.append(combo)
+                        else:
+                            invalid_combos_count += 1
+                    # reference_time is null, member is not null
+                    elif (pd.isnull(combo[2]) and not pd.isnull(combo[3])):
+                        temp = var_df[
+                            (var_df['configuration_name'] == combo[0]) &
+                            (var_df['location_id'] == combo[1]) &
+                            (var_df['member'] == combo[3])
+                            ]
+                        if not temp.empty:
+                            valid_combos.append(combo)
+                        else:
+                            invalid_combos_count += 1
+                    # reference_time is not null, member is null
+                    elif (not pd.isnull(combo[2]) and pd.isnull(combo[3])):
+                        temp = var_df[
+                            (var_df['configuration_name'] == combo[0]) &
+                            (var_df['location_id'] == combo[1]) &
+                            (var_df['reference_time'] == combo[2])
+                            ]
+                        if not temp.empty:
+                            valid_combos.append(combo)
+                        else:
+                            invalid_combos_count += 1
+                    # reference_time is not null, member is not null
+                    else:
+                        temp = var_df[
+                            (var_df['configuration_name'] == combo[0]) &
+                            (var_df['location_id'] == combo[1]) &
+                            (var_df['reference_time'] == combo[2]) &
+                            (var_df['member'] == combo[3])
+                            ]
+                        if not temp.empty:
+                            valid_combos.append(combo)
+                        else:
+                            invalid_combos_count += 1
+                filtered_schema[variable] = valid_combos
+                if invalid_combos_count > 0:
+                    logger.info(f"""
+                        Removed {invalid_combos_count} invalid combinations
+                        from the schema.
+                    """)
+        logger.info("Schema filtering complete.")
         return filtered_schema
 
     def _timeseries_format_plot(
@@ -296,62 +383,193 @@ class TEEHRDataFrameAccessor:
             height=800
             )
 
-        # add data to plot
-        for combo in schema[variable]:
-            if pd.isnull(combo[2]):  # reference_time is null
-                logger.info(f"Processing combination: {combo}")
-                logger.info(f"""
-                            reference_time == NaT, ignoring reference_time for
-                            combo: {combo}
-                            """)
-                temp = df[
-                    (df['configuration_name'] == combo[0]) &
-                    (df['location_id'] == combo[1])
-                    ]
-                if not temp.empty:
-                    logger.info(f"Plotting data for combination: {combo}")
-                    p.line(
-                        temp.value_time,
-                        temp.value,
-                        legend_label=f"{combo[0]} - {combo[1]}",
-                        line_width=1,
-                        color=next(palette)
-                    )
+        # add data to plot (primary timeseries)
+        if self._df.attrs['table_type'] == 'primary_timeseries':
+            for combo in schema[variable]:
+                # reference_time is null
+                if pd.isnull(combo[2]):
+                    logger.info(f"Processing combination: {combo}")
+                    logger.info(f"""
+                                reference_time == NaT, ignoring reference_time
+                                for combo: {combo}
+                                """)
+                    temp = df[
+                        (df['configuration_name'] == combo[0]) &
+                        (df['location_id'] == combo[1])
+                        ]
+                    if not temp.empty:
+                        logger.info(f"Plotting data for combination: {combo}")
+                        p.line(
+                            temp.value_time,
+                            temp.value,
+                            legend_label=f"{combo[0]} - {combo[1]}",
+                            line_width=1,
+                            color=next(palette)
+                        )
+                    else:
+                        logger.warning(f"No data for combination: {combo}")
+                # reference_time is not null
                 else:
-                    logger.warning(f"No data for combination: {combo}")
-            else:  # reference_time is not null
-                logger.info(f"Processing combination: {combo}")
-                temp = df[
-                    (df['configuration_name'] == combo[0]) &
-                    (df['location_id'] == combo[1]) &
-                    (df['reference_time'] == combo[2])
-                    ]
-                if not temp.empty:
-                    logger.info(f"Plotting data for combination: {combo}")
-                    p.line(
-                        temp.value_time,
-                        temp.value,
-                        legend_label=f"{combo[0]} - {combo[1]} - {combo[2]}",
-                        line_width=1,
-                        color=next(palette)
-                    )
+                    logger.info(f"Processing combination: {combo}")
+                    temp = df[
+                        (df['configuration_name'] == combo[0]) &
+                        (df['location_id'] == combo[1]) &
+                        (df['reference_time'] == combo[2])
+                        ]
+                    if not temp.empty:
+                        logger.info(f"Plotting data for combination: {combo}")
+                        label = f"{combo[0]} - {combo[1]} - {combo[2]}"
+                        p.line(
+                            temp.value_time,
+                            temp.value,
+                            legend_label=f"{label}",
+                            line_width=1,
+                            color=next(palette)
+                        )
+                    else:
+                        logger.warning(f"No data for combination: {combo}")
+
+        # add data to plot (secondary timeseries)
+        else:
+            for combo in schema[variable]:
+                # reference_time is null, member is null
+                if (pd.isnull(combo[2]) and pd.isnull(combo[3])):
+                    logger.info(f"Processing combination: {combo}")
+                    logger.info(f"""
+                                reference_time == NaT and member == None,
+                                ignoring reference_time and member for
+                                combo: {combo}
+                                """)
+                    temp = df[
+                        (df['configuration_name'] == combo[0]) &
+                        (df['location_id'] == combo[1])
+                        ]
+                    if not temp.empty:
+                        logger.info(f"Plotting data for combination: {combo}")
+                        p.line(
+                            temp.value_time,
+                            temp.value,
+                            legend_label=f"{combo[0]} - {combo[1]}",
+                            line_width=1,
+                            color=next(palette)
+                        )
+                    else:
+                        logger.warning(f"No data for combination: {combo}")
+                # reference_time is null, member is not null
+                elif (pd.isnull(combo[2]) and not pd.isnull(combo[3])):
+                    logger.info(f"Processing combination: {combo}")
+                    logger.info(f"""
+                                reference_time == NaT, ignoring reference_time
+                                for combo: {combo}
+                                """)
+                    temp = df[
+                        (df['configuration_name'] == combo[0]) &
+                        (df['location_id'] == combo[1]) &
+                        (df['member'] == combo[3])
+                        ]
+                    if not temp.empty:
+                        logger.info(f"Plotting data for combination: {combo}")
+                        label = f"{combo[0]} - {combo[1]} - {combo[3]}"
+                        p.line(
+                            temp.value_time,
+                            temp.value,
+                            legend_label=f"{label}",
+                            line_width=1,
+                            color=next(palette)
+                        )
+                    else:
+                        logger.warning(f"No data for combination: {combo}")
+                # reference_time is not null, member is null
+                elif (not pd.isnull(combo[2]) and pd.isnull(combo[3])):
+                    logger.info(f"Processing combination: {combo}")
+                    logger.info(f"""
+                                member == None, ignoring member for
+                                combo: {combo}
+                                """)
+                    temp = df[
+                        (df['configuration_name'] == combo[0]) &
+                        (df['location_id'] == combo[1]) &
+                        (df['reference_time'] == combo[2])
+                        ]
+                    if not temp.empty:
+                        logger.info(f"Plotting data for combination: {combo}")
+                        label = f"{combo[0]} - {combo[1]} - {combo[2]}"
+                        p.line(
+                            temp.value_time,
+                            temp.value,
+                            legend_label=f"{label}",
+                            line_width=1,
+                            color=next(palette)
+                        )
+                    else:
+                        logger.warning(f"No data for combination: {combo}")
+                # reference_time is not null, member is not null
                 else:
-                    logger.warning(f"No data for combination: {combo}")
+                    logger.info(f"Processing combination: {combo}")
+                    temp = df[
+                        (df['configuration_name'] == combo[0]) &
+                        (df['location_id'] == combo[1]) &
+                        (df['reference_time'] == combo[2]) &
+                        (df['member'] == combo[3])
+                        ]
+                    if not temp.empty:
+                        logger.info(f"Plotting data for combination: {combo}")
+                        label = f"{combo[0]} - {combo[1]} - {combo[2]} - \
+                                  {combo[3]}"
+                        p.line(
+                            temp.value_time,
+                            temp.value,
+                            legend_label=f"{label}",
+                            line_width=1,
+                            color=next(palette)
+                        )
+                    else:
+                        logger.warning(f"No data for combination: {combo}")
 
         # format plot
         p = self._timeseries_format_plot(plot=p)
 
-        # output figure
-        if output_dir:
-            fname = Path(output_dir, f'timeseries_plot_{variable}.html')
-            output_file(filename=fname, title=f'Timeseries Plot [{variable}]', mode='inline')
-            logger.info(f"Saving timeseries plot at {output_dir}")
-            save(p)
-            logger.info(f"Timeseries plot saved at {fname}")
+        # output figure (primary timeseries)
+        if self._df.attrs['table_type'] == 'primary_timeseries':
+            if output_dir:
+                fname = Path(
+                    output_dir,
+                    f'primary_timeseries_plot_{variable}.html'
+                    )
+                output_file(
+                    filename=fname,
+                    title=f'Primary Timeseries Plot [{variable}]',
+                    mode='inline'
+                        )
+                logger.info(f"Saving primary timeseries plot at {output_dir}")
+                save(p)
+                logger.info(f"Primary Timeseries plot saved at {fname}")
+            else:
+                logger.info("No output directory specified, displaying plot.")
+                show(p)
+                logger.info("Primary Timeseries plot displayed.")
+
+        # output figure (secondary timeseries)
         else:
-            logger.info("No output directory specified, displaying plot.")
-            show(p)
-            logger.info("Timeseries plot displayed.")
+            if output_dir:
+                fname = Path(
+                    output_dir,
+                    f'secondary_timeseries_plot_{variable}.html'
+                    )
+                output_file(
+                    filename=fname,
+                    title=f'Secondary Timeseries Plot [{variable}]',
+                    mode='inline'
+                        )
+                logger.info(
+                    f"Saving secondary timeseries plot at {output_dir}"
+                    )
+                save(p)
+                logger.info(f"Secondary Timeseries plot saved at {fname}")
+            else:
+                logger.info("No output directory specified, displaying plot.")
+                show(p)
+                logger.info("Secondary Timeseries plot displayed.")
 
         return
 
@@ -381,11 +599,12 @@ class TEEHRDataFrameAccessor:
         ensures the output directory exists before saving the plots.
         """
         # check table type
-        if self._df.attrs['table_type'] != 'primary_timeseries':
+        if (self._df.attrs['table_type'] != 'primary_timeseries' and
+           self._df.attrs['table_type'] != 'secondary_timeseries'):
             table_type_str = self.attrs['table_type']
             raise AttributeError(f"""
-                Expected table_type == "primary_timeseries",
-                got table_type = {table_type_str}
+                Expected table_type == "primary_timeseries" or
+                "secondary_timeseries", got table_type = {table_type_str}
             """)
 
         # check for output location
@@ -489,7 +708,7 @@ class TEEHRDataFrameAccessor:
         else:
             logger.info("No output directory specified, displaying plot.")
             show(p)
-            logger.info(f"Location map displayed.")
+            logger.info("Location map displayed.")
 
         return
 
@@ -681,14 +900,18 @@ class TEEHRDataFrameAccessor:
         # output figure
         if output_dir:
             fname = Path(output_dir, 'location_attributes_map.html')
-            output_file(filename=fname, title='Location Attributes Map', mode='inline')
+            output_file(
+                filename=fname,
+                title='Location Attributes Map',
+                mode='inline'
+                )
             logger.info(f"Saving location attributes map at {output_dir}")
             save(p)
             logger.info(f"Location attributes map at {fname}")
         else:
             logger.info("No output directory specified, displaying plot.")
             show(p)
-            logger.info(f"Location attributes map displayed.")
+            logger.info("Location attributes map displayed.")
 
         return
 
@@ -750,7 +973,10 @@ class TEEHRDataFrameAccessor:
         geo_data = self._location_attributes_format_points()
 
         # generate map
-        self._location_attributes_generate_map(geo_data=geo_data, output_dir=output_dir)
+        self._location_attributes_generate_map(
+            geo_data=geo_data,
+            output_dir=output_dir
+            )
 
     def _location_crosswalks_format_points(self) -> dict:
         """Generate dictionary for point plotting."""
@@ -806,14 +1032,18 @@ class TEEHRDataFrameAccessor:
         # output figure
         if output_dir:
             fname = Path(output_dir, 'location_crosswalks_map.html')
-            output_file(filename=fname, title='Location Crosswalks Map', mode='inline')
+            output_file(
+                filename=fname,
+                title='Location Crosswalks Map',
+                mode='inline'
+                )
             logger.info(f"Saving location crosswalks map at {output_dir}")
             save(p)
             logger.info(f"Location crosswalks map saved at {fname}")
         else:
             logger.info("No output directory specified, displaying plot.")
             show(p)
-            logger.info(f"Location crosswalks map displayed.")
+            logger.info("Location crosswalks map displayed.")
 
         return
 
@@ -875,4 +1105,7 @@ class TEEHRDataFrameAccessor:
         geo_data = self._location_crosswalks_format_points()
 
         # generate map
-        self._location_crosswalks_generate_map(geo_data=geo_data, output_dir=output_dir)
+        self._location_crosswalks_generate_map(
+            geo_data=geo_data,
+            output_dir=output_dir
+            )

--- a/tests/test_dataframe_accessor.py
+++ b/tests/test_dataframe_accessor.py
@@ -1,4 +1,4 @@
-import shutil
+"""This module tests the dataframe_accessor functions."""
 import pandas as pd
 import geopandas as gpd
 import pytest
@@ -10,6 +10,7 @@ import tempfile
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 def test_init_with_dataframe():
     """Test validation with pd.DataFrame."""
@@ -27,6 +28,7 @@ def test_init_with_dataframe():
     assert accessor._df is not None
     assert accessor._gdf is None
 
+
 def test_init_with_geodataframe():
     """Test validation with gpd.GeoDataFrame."""
     gdf = gpd.GeoDataFrame({
@@ -40,11 +42,13 @@ def test_init_with_geodataframe():
     assert accessor._df is None
     assert accessor._gdf is not None
 
+
 def test_validate_missing_table_type():
     """Test missing table type."""
     df = pd.DataFrame({'a': [1, 2, 3]})
     with pytest.raises(AttributeError):
         TEEHRDataFrameAccessor._validate(None, df)
+
 
 def test_validate_missing_fields():
     """Test missing columns."""
@@ -53,7 +57,8 @@ def test_validate_missing_fields():
     with pytest.raises(AttributeError):
         TEEHRDataFrameAccessor._validate(None, df)
 
-def test_timeseries_plot(tmpdir):
+
+def test_primary_timeseries_plot(tmpdir):
     """Test timeseries plot."""
     df = pd.DataFrame({
         'variable_name': ['var1', 'var1'],
@@ -67,7 +72,26 @@ def test_timeseries_plot(tmpdir):
     df.attrs['table_type'] = 'primary_timeseries'
     accessor = TEEHRDataFrameAccessor(df)
     accessor.timeseries_plot(output_dir=tmpdir)
-    assert Path(tmpdir, 'timeseries_plot_var1.html').is_file()
+    assert Path(tmpdir, 'primary_timeseries_plot_var1.html').is_file()
+
+
+def test_secondary_timeseries_plot(tmpdir):
+    """Test secondary timeseries plot."""
+    df = pd.DataFrame({
+        'variable_name': ['var1', 'var1'],
+        'configuration_name': ['config1', 'config1'],
+        'location_id': ['loc1', 'loc1'],
+        'reference_time': [None, None],
+        'value_time': pd.to_datetime(['2021-01-01', '2021-01-02']),
+        'value': [1, 2],
+        'unit_name': ['unit1', 'unit1'],
+        'member': [None, None]
+    })
+    df.attrs['table_type'] = 'secondary_timeseries'
+    accessor = TEEHRDataFrameAccessor(df)
+    accessor.timeseries_plot(output_dir=tmpdir)
+    assert Path(tmpdir, 'secondary_timeseries_plot_var1.html').is_file()
+
 
 def test_locations_map(tmpdir):
     """Test locations table mapping."""
@@ -82,6 +106,7 @@ def test_locations_map(tmpdir):
     accessor.locations_map(output_dir=tmpdir)
     assert Path(tmpdir, 'location_map.html').is_file()
 
+
 def test_location_attributes_map(tmpdir):
     """Test location_attributes table mapping."""
     gdf = gpd.GeoDataFrame({
@@ -95,6 +120,7 @@ def test_location_attributes_map(tmpdir):
     accessor = TEEHRDataFrameAccessor(gdf)
     accessor.location_attributes_map(output_dir=tmpdir)
     assert Path(tmpdir, 'location_attributes_map.html').is_file()
+
 
 def test_location_crosswalks_map(tmpdir):
     """Test location_crosswalks table mapping."""
@@ -118,7 +144,13 @@ if __name__ == "__main__":
         test_init_with_geodataframe()
         test_validate_missing_table_type()
         test_validate_missing_fields()
-        test_timeseries_plot(
+        test_primary_timeseries_plot(
+            tempfile.mkdtemp(
+                prefix="1-",
+                dir=tmpdir
+            )
+        )
+        test_secondary_timeseries_plot(
             tempfile.mkdtemp(
                 prefix="1-",
                 dir=tmpdir

--- a/tests/test_dataframe_accessor.py
+++ b/tests/test_dataframe_accessor.py
@@ -64,7 +64,7 @@ def test_primary_timeseries_plot(tmpdir):
         'variable_name': ['var1', 'var1'],
         'configuration_name': ['config1', 'config1'],
         'location_id': ['loc1', 'loc1'],
-        'reference_time': [None, None],
+        'reference_time': ['2021-01-01', None],
         'value_time': pd.to_datetime(['2021-01-01', '2021-01-02']),
         'value': [1, 2],
         'unit_name': ['unit1', 'unit1']
@@ -81,11 +81,11 @@ def test_secondary_timeseries_plot(tmpdir):
         'variable_name': ['var1', 'var1'],
         'configuration_name': ['config1', 'config1'],
         'location_id': ['loc1', 'loc1'],
-        'reference_time': [None, None],
+        'reference_time': ['2021-01-01', None],
         'value_time': pd.to_datetime(['2021-01-01', '2021-01-02']),
         'value': [1, 2],
         'unit_name': ['unit1', 'unit1'],
-        'member': [None, None]
+        'member': [None, 'member1']
     })
     df.attrs['table_type'] = 'secondary_timeseries'
     accessor = TEEHRDataFrameAccessor(df)


### PR DESCRIPTION
- <b>Updated `dataframe_accessor.py`</b>:
  - `_validate()`:
    - Added validation that utilizes secondary_timeseries pandera model 
  - `_timeseries_schema()`:
    - Updated the unique columns to include 'member' field when generating dict of unique combinations for secondary_timeseries table
    - Updated the filter routine used to remove invalid combos to consider both tables
  - `_timeseries_generate_plot()`:
    - Updated adding data to plot to consider both table types and their optional fields
    - Updated export of plot to consider both table types 
  - `timeseries_plot()` 
    - Updated initial check of `table_type` dataframe attribute to consider both tables


- <b>Updated `test_dataframe_accessor .py`</b>:
  - Added  `test_secondary_timeseries_plot()` method