### PR TITLE
adds 'box zoom' option for location mapping (crosswalks, attributes)

### DIFF
--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -903,7 +903,7 @@ class TEEHRDataFrameAccessor:
             x_axis_type="mercator",
             y_axis_type="mercator",
             tooltips=tooltips,
-            tools="pan, wheel_zoom, reset"
+            tools="pan, wheel_zoom, box_zoom, reset"
             )
         p.add_tile(xyz.OpenStreetMap.Mapnik)
 
@@ -1031,7 +1031,7 @@ class TEEHRDataFrameAccessor:
             x_axis_type="mercator",
             y_axis_type="mercator",
             tooltips=tooltips,
-            tools="pan, wheel_zoom, reset"
+            tools="pan, wheel_zoom, box_zoom, reset"
             )
         p.add_tile(xyz.OpenStreetMap.Mapnik)
 


### PR DESCRIPTION
Updates `dataframe_accessor.py` to include a box zoom option when creating bokeh map for `location_crosswalks` table and `location_attributes` table