### PR TITLE
Only add configuration name if it does not already exist

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -66,6 +66,8 @@ master_doc = 'index'
 # Don't show class signature with the class' name.
 # autodoc_class_signature = "separated"
 
+autodoc_default_options = {'inherited-members': True}
+
 autosummary_generate = True
 
 # -- Napolean options --------------------------------------------------------

--- a/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
+++ b/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
@@ -124,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll fetch streamflow data at this gage during the 2024 Hurricane Helene event. Note that we set ``add_configuration_name`` to False since it has already been added in this example evaluation."
+    "We'll fetch streamflow data at this gage during the 2024 Hurricane Helene event."
    ]
   },
   {
@@ -135,8 +135,7 @@
     "# Convert this to a code cell to run locally\n",
     "ev.fetch.usgs_streamflow(\n",
     "    start_date=datetime(2024, 9, 26),\n",
-    "    end_date=datetime(2024, 10, 1),\n",
-    "    add_configuraton_name=False\n",
+    "    end_date=datetime(2024, 10, 1)\n",
     ")\n",
     "```"
    ]

--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -90,6 +90,23 @@ class Fetch:
 
         return location_ids
 
+    def _configuration_name_exists(
+        self, configuration_name: str
+    ) -> bool:
+        """Check if a configuration name exists in the configurations table.
+
+        True: Configuration name exists in the table.
+        False: Configuration name does not exist in the table.
+        """
+        sdf = self.ev.configurations.filter(
+            {
+                "column": "name",
+                "operator": "=",
+                "value": configuration_name
+            }
+        ).to_sdf()
+        return not sdf.rdd.isEmpty()
+
     def usgs_streamflow(
         self,
         start_date: Union[str, datetime, pd.Timestamp],
@@ -208,10 +225,13 @@ class Fetch:
             timeseries_type=timeseries_type
         )
 
-        if add_configuration_name:
+        if (
+            add_configuration_name and
+            not self._configuration_name_exists(USGS_CONFIGURATION_NAME)
+        ):
             self.ev.configurations.add(
                 Configuration(
-                    name="usgs_observations",
+                    name=USGS_CONFIGURATION_NAME,
                     type="primary",
                     description="USGS Observations"
                 )
@@ -339,7 +359,10 @@ class Fetch:
             timeseries_type=timeseries_type
         )
 
-        if add_configuration_name:
+        if (
+            add_configuration_name and
+            not self._configuration_name_exists(ev_configuration_name)
+        ):
             self.ev.configurations.add(
                 Configuration(
                     name=ev_configuration_name,
@@ -492,7 +515,10 @@ class Fetch:
             timeseries_type=timeseries_type
         )
 
-        if add_configuration_name:
+        if (
+            add_configuration_name and
+            not self._configuration_name_exists(ev_configuration_name)
+        ):
             self.ev.configurations.add(
                 Configuration(
                     name=ev_configuration_name,
@@ -691,7 +717,12 @@ class Fetch:
             timeseries_type=timeseries_type
         )
 
-        if add_configuration_name:
+        if (
+            add_configuration_name and
+            not self._configuration_name_exists(
+                ev_config["configuration_name"]
+            )
+        ):
             self.ev.configurations.add(
                 Configuration(
                     name=ev_config["configuration_name"],
@@ -889,7 +920,12 @@ class Fetch:
             variable_mapper=NWM_VARIABLE_MAPPER
         )
 
-        if add_configuration_name:
+        if (
+            add_configuration_name and
+            not self._configuration_name_exists(
+                ev_config["configuration_name"]
+            )
+        ):
             self.ev.configurations.add(
                 Configuration(
                     name=ev_config["configuration_name"],

--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -117,8 +117,7 @@ class Fetch:
         filter_no_data: bool = True,
         convert_to_si: bool = True,
         overwrite_output: Optional[bool] = False,
-        timeseries_type: TimeseriesTypeEnum = "primary",
-        add_configuration_name: bool = True
+        timeseries_type: TimeseriesTypeEnum = "primary"
     ):
         """Fetch USGS gage data and load into the TEEHR dataset.
 
@@ -157,9 +156,6 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "primary".
-        add_configuration_name : bool
-            If True, adds the configuration name ``usgs_observations`` to the
-            Evaluation. Default is True.
 
         Examples
         --------
@@ -226,7 +222,6 @@ class Fetch:
         )
 
         if (
-            add_configuration_name and
             not self._configuration_name_exists(USGS_CONFIGURATION_NAME)
         ):
             self.ev.configurations.add(
@@ -254,8 +249,7 @@ class Fetch:
         chunk_by: Union[NWMChunkByEnum, None] = None,
         overwrite_output: Optional[bool] = False,
         domain: Optional[SupportedNWMRetroDomainsEnum] = "CONUS",
-        timeseries_type: TimeseriesTypeEnum = "secondary",
-        add_configuration_name: bool = True
+        timeseries_type: TimeseriesTypeEnum = "secondary"
     ):
         """Fetch NWM retrospective point data and load into the TEEHR dataset.
 
@@ -292,8 +286,6 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "primary".
-        add_configuration_name : bool
-            If True, adds the configuration name to the Evaluation. Default is True.
 
         Examples
         --------
@@ -360,7 +352,6 @@ class Fetch:
         )
 
         if (
-            add_configuration_name and
             not self._configuration_name_exists(ev_configuration_name)
         ):
             self.ev.configurations.add(
@@ -390,8 +381,7 @@ class Fetch:
         overwrite_output: Optional[bool] = False,
         domain: Optional[SupportedNWMRetroDomainsEnum] = "CONUS",
         location_id_prefix: Optional[Union[str, None]] = None,
-        timeseries_type: TimeseriesTypeEnum = "primary",
-        add_configuration_name: bool = True
+        timeseries_type: TimeseriesTypeEnum = "primary"
     ):
         """
         Fetch NWM retrospective gridded data, calculate zonal statistics (currently only
@@ -440,9 +430,6 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "primary".
-        add_configuration_name : bool
-            If True, adds the configuration name to the Evaluation.
-            Default is True.
 
         Notes
         -----
@@ -516,7 +503,6 @@ class Fetch:
         )
 
         if (
-            add_configuration_name and
             not self._configuration_name_exists(ev_configuration_name)
         ):
             self.ev.configurations.add(
@@ -551,8 +537,7 @@ class Fetch:
         stepsize: Optional[int] = 100,
         ignore_missing_file: Optional[bool] = True,
         overwrite_output: Optional[bool] = False,
-        timeseries_type: TimeseriesTypeEnum = "secondary",
-        add_configuration_name: bool = True
+        timeseries_type: TimeseriesTypeEnum = "secondary"
     ):
         """Fetch operational NWM point data and load into the TEEHR dataset.
 
@@ -618,8 +603,6 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "secondary".
-        add_configuration_name : bool
-            If True, adds the configuration name to the Evaluation. Default is True.
 
         Notes
         -----
@@ -718,7 +701,6 @@ class Fetch:
         )
 
         if (
-            add_configuration_name and
             not self._configuration_name_exists(
                 ev_config["configuration_name"]
             )
@@ -755,8 +737,7 @@ class Fetch:
         ignore_missing_file: Optional[bool] = True,
         overwrite_output: Optional[bool] = False,
         location_id_prefix: Optional[Union[str, None]] = None,
-        timeseries_type: TimeseriesTypeEnum = "primary",
-        add_configuration_name: bool = True
+        timeseries_type: TimeseriesTypeEnum = "primary"
     ):
         """
         Fetch NWM operational gridded data, calculate zonal statistics (currently only
@@ -819,8 +800,6 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "primary".
-        add_configuration_name : bool
-            If True, adds the configuration name to the Evaluation. Default is True.
 
         Notes
         -----
@@ -921,7 +900,6 @@ class Fetch:
         )
 
         if (
-            add_configuration_name and
             not self._configuration_name_exists(
                 ev_config["configuration_name"]
             )

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -43,7 +43,13 @@ def test_fetch_and_load_nwm_retro_points(tmpdir):
         end_date=datetime(2022, 2, 23)
     )
 
-    _ = ev.primary_timeseries.to_pandas()
+    # Make sure second fetch succeeds.
+    ev.fetch.usgs_streamflow(
+        start_date=datetime(2022, 2, 24),
+        end_date=datetime(2022, 2, 25)
+    )
+
+    pts_df = ev.primary_timeseries.to_pandas()
 
     ev.location_crosswalks.load_parquet(
         in_path=CROSSWALK_FILEPATH
@@ -57,6 +63,16 @@ def test_fetch_and_load_nwm_retro_points(tmpdir):
     )
     ts_df = ev.secondary_timeseries.to_pandas()
 
+    # Make sure second fetch succeeds.
+    ev.fetch.nwm_retrospective_points(
+        nwm_version="nwm30",
+        variable_name="streamflow",
+        start_date=datetime(2022, 2, 24),
+        end_date=datetime(2022, 2, 25)
+    )
+
+    assert pts_df.value_time.min() == pd.Timestamp("2022-02-22 00:00:00")
+    assert pts_df.value_time.max() == pd.Timestamp("2022-02-25 00:00:00")
     assert isinstance(ts_df, pd.DataFrame)
     assert set(ts_df.columns.tolist()) == set([
             "reference_time",


### PR DESCRIPTION
Adds logic in fetching to:
- check if configuration name exists in the configurations table
- automatically adds configuration name if it does not exist in the table, if it does exist continue with loading
- remove `add_configuration_name` flag since it seems unnecessary and could cause problems.  I can't think of a reason why the name shouldn't be added if it doesn't exist, since validation will then fail 

Resolves #397 