### PR TITLE
407 add ability to specify z hours when fetching nwm operational data

### DIFF
--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -565,7 +565,9 @@ class Fetch:
         stepsize: Optional[int] = 100,
         ignore_missing_file: Optional[bool] = True,
         overwrite_output: Optional[bool] = False,
-        timeseries_type: TimeseriesTypeEnum = "secondary"
+        timeseries_type: TimeseriesTypeEnum = "secondary",
+        starting_z_hour: Optional[int] = None,
+        ending_z_hour: Optional[int] = None
     ):
         """Fetch operational NWM point data and load into the TEEHR dataset.
 
@@ -641,6 +643,12 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "secondary".
+        starting_z_hour : Optional[int]
+            The starting z_hour to include in the output. If None, all z_hours
+            are included for the first day. Default is None. Must be between 0 and 23.
+        ending_z_hour : Optional[int]
+            The ending z_hour to include in the output. If None, all z_hours
+            are included for the last day. Default is None. Must be between 0 and 23.
 
         Notes
         -----
@@ -735,7 +743,9 @@ class Fetch:
             ignore_missing_file=ignore_missing_file,
             overwrite_output=overwrite_output,
             variable_mapper=NWM_VARIABLE_MAPPER,
-            timeseries_type=timeseries_type
+            timeseries_type=timeseries_type,
+            starting_z_hour=starting_z_hour,
+            ending_z_hour=ending_z_hour
         )
 
         if (
@@ -775,7 +785,9 @@ class Fetch:
         ignore_missing_file: Optional[bool] = True,
         overwrite_output: Optional[bool] = False,
         location_id_prefix: Optional[Union[str, None]] = None,
-        timeseries_type: TimeseriesTypeEnum = "primary"
+        timeseries_type: TimeseriesTypeEnum = "primary",
+        starting_z_hour: Optional[int] = None,
+        ending_z_hour: Optional[int] = None
     ):
         """
         Fetch NWM operational gridded data, calculate zonal statistics (currently only
@@ -848,6 +860,12 @@ class Fetch:
         timeseries_type : str
             Whether to consider as the "primary" or "secondary" timeseries.
             Default is "primary".
+        starting_z_hour : Optional[int]
+            The starting z_hour to include in the output. If None, all z_hours
+            are included for the first day. Default is None. Must be between 0 and 23.
+        ending_z_hour : Optional[int]
+            The ending z_hour to include in the output. If None, all z_hours
+            are included for the last day. Default is None. Must be between 0 and 23.
 
         Notes
         -----
@@ -944,7 +962,9 @@ class Fetch:
             ignore_missing_file=ignore_missing_file,
             overwrite_output=overwrite_output,
             location_id_prefix=location_id_prefix,
-            variable_mapper=NWM_VARIABLE_MAPPER
+            variable_mapper=NWM_VARIABLE_MAPPER,
+            starting_z_hour=starting_z_hour,
+            ending_z_hour=ending_z_hour,
         )
 
         if (

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -185,12 +185,7 @@ def fetch_and_format_nwm_grids(
         output_parquet_dir.mkdir(parents=True)
 
     # Format file list into a dataframe and group by reference time
-    day_pattern = re.compile(r'nwm.[0-9]+')
-    tz_pattern = re.compile(r't[0-9]+z')
-
     df_refs = parse_nwm_json_paths(
-        day_pattern=day_pattern,
-        tz_pattern=tz_pattern,
         json_paths=json_paths
     )
 

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -218,12 +218,7 @@ def fetch_and_format_nwm_points(
         output_parquet_dir.mkdir(parents=True)
 
     # Format file list into a dataframe and group by specified method
-    day_pattern = re.compile(r'nwm.[0-9]+')
-    tz_pattern = re.compile(r't[0-9]+z')
-
     df_refs = parse_nwm_json_paths(
-        day_pattern=day_pattern,
-        tz_pattern=tz_pattern,
         json_paths=json_paths
     )
 

--- a/src/teehr/fetching/utils.py
+++ b/src/teehr/fetching/utils.py
@@ -44,13 +44,13 @@ DAY_PATTERN = re.compile(r'nwm.[0-9]+')
 logger = logging.getLogger(__name__)
 
 
-def limit_start_to_z_hour(
+def start_on_z_hour(
     start_date: datetime,
-    start_tz: int,
+    start_z_hour: int,
     gcs_component_paths: List[str]
 ):
     """Limit the start date to a specified z-hour."""
-    logger.info(f"Limiting the start date to z-hour: {start_tz}.")
+    logger.info(f"Limiting the start date to z-hour: {start_z_hour}.")
     formatted_start_date = start_date.strftime("%Y%m%d")
     return_list = []
     for path in gcs_component_paths:
@@ -58,21 +58,21 @@ def limit_start_to_z_hour(
         day = res.split(".")[1]
         tz = re.search(TZ_PATTERN, path).group()
         if day == formatted_start_date:
-            if int(tz[1:-1]) >= start_tz:
+            if int(tz[1:-1]) >= start_z_hour:
                 return_list.append(path)
         else:
             return_list.append(path)
     return return_list
 
 
-def limit_end_to_z_hour(
+def end_on_z_hour(
     start_date: datetime,
     ingest_days: int,
-    end_tz: int,
+    end_z_hour: int,
     gcs_component_paths: List[str]
 ):
     """Limit the end date to a specified z-hour."""
-    logger.info(f"Limiting the end date to z-hour: {end_tz}.")
+    logger.info(f"Limiting the end date to z-hour: {end_z_hour}.")
     dates = pd.date_range(start=start_date, periods=ingest_days, freq="1d")
     formatted_end_date = dates[-1].strftime("%Y%m%d")
     return_list = []
@@ -82,7 +82,7 @@ def limit_end_to_z_hour(
         day = res.split(".")[1]
         tz = re.search(TZ_PATTERN, path).group()
         if day == formatted_end_date:
-            if int(tz[1:-1]) <= end_tz:
+            if int(tz[1:-1]) <= end_z_hour:
                 return_list.append(path)
         else:
             return_list.append(path)

--- a/src/teehr/fetching/utils.py
+++ b/src/teehr/fetching/utils.py
@@ -37,26 +37,71 @@ from teehr.fetching.const import (
 )
 import teehr.models.pandera_dataframe_schemas as schemas
 
+TZ_PATTERN = re.compile(r't[0-9]+z')
+DAY_PATTERN = re.compile(r'nwm.[0-9]+')
+
 
 logger = logging.getLogger(__name__)
 
 
+def limit_start_to_z_hour(
+    start_date: datetime,
+    start_tz: int,
+    gcs_component_paths: List[str]
+):
+    """Limit the start date to a specified z-hour."""
+    logger.info(f"Limiting the start date to z-hour: {start_tz}.")
+    formatted_start_date = start_date.strftime("%Y%m%d")
+    return_list = []
+    for path in gcs_component_paths:
+        res = re.search(DAY_PATTERN, path).group()
+        day = res.split(".")[1]
+        tz = re.search(TZ_PATTERN, path).group()
+        if day == formatted_start_date:
+            if int(tz[1:-1]) >= start_tz:
+                return_list.append(path)
+        else:
+            return_list.append(path)
+    return return_list
+
+
+def limit_end_to_z_hour(
+    start_date: datetime,
+    ingest_days: int,
+    end_tz: int,
+    gcs_component_paths: List[str]
+):
+    """Limit the end date to a specified z-hour."""
+    logger.info(f"Limiting the end date to z-hour: {end_tz}.")
+    dates = pd.date_range(start=start_date, periods=ingest_days, freq="1d")
+    formatted_end_date = dates[-1].strftime("%Y%m%d")
+    return_list = []
+    reversed_list = sorted(gcs_component_paths, reverse=True)
+    for path in reversed_list:
+        res = re.search(DAY_PATTERN, path).group()
+        day = res.split(".")[1]
+        tz = re.search(TZ_PATTERN, path).group()
+        if day == formatted_end_date:
+            if int(tz[1:-1]) <= end_tz:
+                return_list.append(path)
+        else:
+            return_list.append(path)
+    return sorted(return_list)
+
+
 def parse_nwm_json_paths(
-    day_pattern: re.Pattern,
-    tz_pattern: re.Pattern,
     json_paths: List[str]
 ) -> pd.DataFrame:
     """Parse the day and z-hour from the json paths, returning a DataFrame."""
     logger.debug("Parsing day and z-hour from json paths.")
-
     days = []
     z_hours = []
     for path in json_paths:
         filename = Path(path).name
         if path.split(":")[0] == "s3":
-            res = re.search(day_pattern, path).group()
+            res = re.search(DAY_PATTERN, path).group()
             days.append(res.split(".")[1])
-            z_hours.append(re.search(tz_pattern, filename).group())
+            z_hours.append(re.search(TZ_PATTERN, filename).group())
         else:
             days.append(filename.split(".")[1])
             z_hours.append(filename.split(".")[3])

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -146,7 +146,7 @@ def test_fetch_and_load_nwm_operational_points(tmpdir):
         nwm_version="nwm30",
         prioritize_analysis_valid_time=True,
         t_minus_hours=[0],
-        process_by_z_hour=False
+        process_by_z_hour=False,
     )
     ts_df = ev.secondary_timeseries.to_pandas()
 

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -147,6 +147,8 @@ def test_fetch_and_load_nwm_operational_points(tmpdir):
         prioritize_analysis_valid_time=True,
         t_minus_hours=[0],
         process_by_z_hour=False,
+        starting_z_hour=3,
+        ending_z_hour=20
     )
     ts_df = ev.secondary_timeseries.to_pandas()
 
@@ -162,9 +164,9 @@ def test_fetch_and_load_nwm_operational_points(tmpdir):
             "member"
             ])
     assert ts_df.unit_name.iloc[0] == "m^3/s"
-    assert np.isclose(ts_df.value.sum(), np.float32(658.14))
-    assert ts_df.value_time.min() == pd.Timestamp("2024-02-22 00:00:00")
-    assert ts_df.value_time.max() == pd.Timestamp("2024-02-22 23:00:00")
+    assert np.isclose(ts_df.value.sum(), np.float32(492.21))
+    assert ts_df.value_time.min() == pd.Timestamp("2024-02-22 03:00:00")
+    assert ts_df.value_time.max() == pd.Timestamp("2024-02-22 20:00:00")
 
 
 @pytest.mark.skip(reason="This takes forever!")
@@ -186,7 +188,9 @@ def test_fetch_and_load_nwm_operational_grids(tmpdir):
         nwm_version="nwm30",
         prioritize_analysis_valid_time=True,
         t_minus_hours=[0],
-        location_id_prefix="huc10"
+        location_id_prefix="huc10",
+        starting_z_hour=2,
+        ending_z_hour=22
     )
     ts_df = ev.primary_timeseries.to_pandas()
 
@@ -202,8 +206,8 @@ def test_fetch_and_load_nwm_operational_grids(tmpdir):
             ])
     assert ts_df.unit_name.iloc[0] == "mm/s"
     assert np.isclose(ts_df.value.sum(), np.float32(0.0))
-    assert ts_df.value_time.min() == pd.Timestamp("2024-02-22 00:00:00")
-    assert ts_df.value_time.max() == pd.Timestamp("2024-02-22 23:00:00")
+    assert ts_df.value_time.min() == pd.Timestamp("2024-02-22 02:00:00")
+    assert ts_df.value_time.max() == pd.Timestamp("2024-02-22 22:00:00")
     file_list = list(
         Path(
             tmpdir,
@@ -213,7 +217,7 @@ def test_fetch_and_load_nwm_operational_grids(tmpdir):
             "variable_name=rainfall_hourly_rate"
             ).glob("*.parquet")
     )
-    assert len(file_list) == 8
+    assert len(file_list) == 7
 
 
 if __name__ == "__main__":

--- a/tests/test_nwm_fetching_utils.py
+++ b/tests/test_nwm_fetching_utils.py
@@ -1,6 +1,5 @@
 """Test NWM fetching utils."""
 from pathlib import Path
-import re
 from datetime import datetime
 
 import tempfile
@@ -43,11 +42,7 @@ def test_parsing_remote_json_paths(tmpdir):
         "s3://ciroh-nwm-zarr-copy/national-water-model/nwm.20220101/forcing_medium_range/nwm.t06z.medium_range.forcing.f039.conus.nc.json"  # noqa
     ]
 
-    day_pattern = re.compile(r'nwm.[0-9]+')
-    tz_pattern = re.compile(r't[0-9]+z')
     df = parse_nwm_json_paths(
-        day_pattern=day_pattern,
-        tz_pattern=tz_pattern,
         json_paths=json_paths
     )
 
@@ -343,8 +338,9 @@ def test_start_end_z_hours():
         start_date=datetime.strptime("2023-11-28", "%Y-%m-%d")
     )
 
-    gcs_component_paths[-1] == 'gcs://national-water-model/nwm.20231129/short_range/nwm.t12z.short_range.channel_rt.f018.conus.nc'  # noqa
-    gcs_component_paths[0] == 'gcs://national-water-model/nwm.20231128/short_range/nwm.t03z.short_range.channel_rt.f001.conus.nc'  # noqa
+    assert gcs_component_paths[-1] == 'gcs://national-water-model/nwm.20231129/short_range/nwm.t12z.short_range.channel_rt.f018.conus.nc'  # noqa
+    assert gcs_component_paths[0] == 'gcs://national-water-model/nwm.20231128/short_range/nwm.t03z.short_range.channel_rt.f001.conus.nc'  # noqa
+    assert len(gcs_component_paths) == 612
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Adds `starting_z_hour` and `ending_z_hour` arguments to operational NWM fetching methods (point, gridded)
* This allows users to fetch forecasts starting and/or ending at a particular z-hour during the day.  This is the case during transitions between some NWM versions (v2.2 to v3.0 happens between the 06z and 12z forecasts during a single day).