### PR TITLE
399 add append and de duplication functionality

### DIFF
--- a/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
+++ b/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
@@ -113,6 +113,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Location ID Prefixes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the location IDs are required to be unique, so TEEHR uses a location ID prefix convention to help ensure uniqueness.\n",
+    "\n",
+    "The location ID prefix is just a string in front of the ID separated by a hyphen, and represents the model configuration. For example, a USGS gage ID could get the prefix \"usgs\" and look something like \"usgs- 03061000\".\n",
+    "\n",
+    "TEEHR provides the ability to specify (or replace) the location ID prefix when loading data.\n",
+    "\n",
+    "Let's load our test locations, replacing the \"gage\" prefix in the source dataset with \"usgs\":"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -122,7 +142,7 @@
    },
    "outputs": [],
    "source": [
-    "ev.locations.load_spatial(location_data_path)"
+    "ev.locations.load_spatial(location_data_path, location_id_prefix=\"usgs\")"
    ]
   },
   {
@@ -281,6 +301,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the IDs in the locations table were given the prefix \"usgs\", we'll need to do the same here."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -302,7 +329,8 @@
     "        \"unit_name\": \"m^3/s\",\n",
     "        \"variable_name\": \"streamflow_hourly_inst\",\n",
     "        \"configuration_name\": \"usgs_observations\"\n",
-    "    }\n",
+    "    },\n",
+    "    location_id_prefix=\"usgs\"\n",
     ")"
    ]
   },
@@ -323,7 +351,7 @@
     "    {\n",
     "        \"column\": \"location_id\",\n",
     "        \"operator\": \"=\",\n",
-    "        \"value\": \"gage-A\"\n",
+    "        \"value\": \"usgs-A\"\n",
     "    }\n",
     ").to_pandas()\n",
     "primary_timeseries_df.head()"
@@ -450,13 +478,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we'll specify the location ID prefix for the primary IDs. If needed we could also update or provide a prefix for the secondary ID using the `secondary_location_id_prefix` argument."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Load the crosswalk data to the crosswalks table\n",
-    "ev.location_crosswalks.load_csv(crosswalk_path)"
+    "ev.location_crosswalks.load_csv(crosswalk_path, primary_location_id_prefix=\"usgs\")"
    ]
   },
   {
@@ -674,6 +709,7 @@
     "    in_path=test_eval_dir,\n",
     "    field_mapping={\"attribute_value\": \"value\"},\n",
     "    pattern=\"test_attr_*.csv\",\n",
+    "    location_id_prefix=\"usgs\",\n",
     ")"
    ]
   },
@@ -794,7 +830,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
+++ b/docs/sphinx/user_guide/notebooks/02_loading_local_data.ipynb
@@ -531,6 +531,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "##### Appending, Upserting, and Overwriting data\n",
+    "Note that the loading methods allow you to add new data to an existing table (`append`, the default) or replace existing data with new values while adding additional data (`upsert`). These are available through the `write_mode` argument. Additionally, when `write_mode=\"overwrite\"`, any existing partitions receiving new data will be overwritten. \n",
+    "\n",
+    "ex.\n",
+    "```python\n",
+    "ev.primary_timeseries.load_parquet(\n",
+    "    in_path=\"<path-to-additional-data.parquet>\",\n",
+    "    field_mapping={\n",
+    "        \"reference_time\": \"reference_time\",\n",
+    "        \"value_time\": \"value_time\",\n",
+    "        \"configuration\": \"configuration_name\",\n",
+    "        \"measurement_unit\": \"unit_name\",\n",
+    "        \"variable_name\": \"variable_name\",\n",
+    "        \"value\": \"value\",\n",
+    "        \"location_id\": \"location_id\"\n",
+    "    },\n",
+    "    constant_field_values={\n",
+    "        \"unit_name\": \"m^3/s\",\n",
+    "        \"variable_name\": \"streamflow_hourly_inst\",\n",
+    "        \"configuration_name\": \"usgs_observations\"\n",
+    "    },\n",
+    "    write_mode=\"append\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding Location Attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "At this point we have added data to the following TEEHR data tables:\n",
     "- locations\n",
     "- configurations\n",

--- a/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
+++ b/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
@@ -99,6 +99,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Location ID Prefixes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the fetching methods automatically append location ID prefixes to the USGS and NWM location IDs. These must existing the location and location crosswalk tables first. See the `Loading Local Data` user guide for more info on specifying the location ID prefix when loading data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Fetching USGS streamgage data"
    ]
   },

--- a/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
+++ b/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
@@ -161,6 +161,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "##### Appending, Upserting, and Overwriting data\n",
+    "Note that the fetching methods allow you to add new data to an existing table (`append`, the default) or replace existing data with new values while adding additional data (`upsert`). These are available through the `write_mode` argument. Additionally, when `write_mode=\"overwrite\"`, any existing partitions receiving new data will be overwritten. \n",
+    "\n",
+    "ex:\n",
+    "\n",
+    "```python\n",
+    "ev.fetch.usgs_streamflow(\n",
+    "    start_date=datetime(2024, 10, 1),\n",
+    "    end_date=datetime(2024, 10, 5),\n",
+    "    write_mode=\"append\"\n",
+    ")\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Fetching NWM streamflow data"
    ]
   },

--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from teehr.utils.utils import remove_dir_if_exists
 import teehr.const as const
 from teehr.fetching.usgs.usgs import usgs_to_parquet
 from teehr.fetching.nwm.nwm_points import nwm_to_parquet
@@ -214,6 +215,9 @@ class Fetch:
 
         usgs_variable_name = USGS_VARIABLE_MAPPER[VARIABLE_NAME][service]
 
+        # Clear out cache
+        remove_dir_if_exists(self.usgs_cache_dir)
+
         usgs_to_parquet(
             sites=sites,
             start_date=start_date,
@@ -352,6 +356,9 @@ class Fetch:
         location_ids = self._get_secondary_location_ids(
             prefix=nwm_version
         )
+
+        # Clear out cache
+        remove_dir_if_exists(self.nwm_cache_dir)
 
         nwm_retro_to_parquet(
             nwm_version=nwm_version,
@@ -511,6 +518,9 @@ class Fetch:
         """ # noqa
         ev_configuration_name = f"{nwm_version}_retrospective"
         ev_variable_name = format_nwm_variable_name(variable_name)
+
+        # Clear out cache
+        remove_dir_if_exists(self.nwm_cache_dir)
 
         nwm_retro_grids_to_parquet(
             nwm_version=nwm_version,
@@ -721,6 +731,10 @@ class Fetch:
             nwm_configuration_name=nwm_configuration,
             nwm_version=nwm_version
         )
+
+        # Clear out cache
+        remove_dir_if_exists(self.nwm_cache_dir)
+
         nwm_to_parquet(
             configuration=nwm_configuration,
             output_type=output_type,
@@ -942,6 +956,10 @@ class Fetch:
             nwm_configuration_name=nwm_configuration,
             nwm_version=nwm_version
         )
+
+        # Clear out cache
+        remove_dir_if_exists(self.nwm_cache_dir)
+
         nwm_grids_to_parquet(
             configuration=nwm_configuration,
             output_type=output_type,

--- a/src/teehr/evaluation/tables/attribute_table.py
+++ b/src/teehr/evaluation/tables/attribute_table.py
@@ -17,11 +17,7 @@ class AttributeTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = AttributeFilter
         self.schema_func = schemas.attribute_schema
-        self.unique_column_set = [
-            "name",
-            "type"
-        ]
-
+        self.unique_column_set = ["name"]
 
     def field_enum(self) -> AttributeFields:
         """Get the attribute fields enum."""

--- a/src/teehr/evaluation/tables/attribute_table.py
+++ b/src/teehr/evaluation/tables/attribute_table.py
@@ -14,10 +14,13 @@ class AttributeTable(DomainTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "attributes"
-        # self.dir = ev.attributes_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = AttributeFilter
         self.schema_func = schemas.attribute_schema
+        self.unique_columns = [
+            "name",
+            "type"
+        ]
 
 
     def field_enum(self) -> AttributeFields:

--- a/src/teehr/evaluation/tables/attribute_table.py
+++ b/src/teehr/evaluation/tables/attribute_table.py
@@ -17,7 +17,7 @@ class AttributeTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = AttributeFilter
         self.schema_func = schemas.attribute_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "name",
             "type"
         ]

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -137,7 +137,7 @@ class BaseTable():
 
         if not existing_sdf.isEmpty():
             df = df.union(existing_sdf)
-            df = df.dropDuplicates()  # subset?
+            df = df.dropDuplicates(self.schema_func().unique)
             pass
 
         (

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -136,10 +136,10 @@ class BaseTable():
 
         if update_columns is not None:
             update_columns = [
-                x for x in self.unique_columns if x not in update_columns
+                x for x in self.unique_column_set if x not in update_columns
             ]
         else:
-            update_columns = self.unique_columns
+            update_columns = self.unique_column_set
 
         # Remove rows from existing_sdf that are to be updated.
         # Concat and re-write.
@@ -192,7 +192,7 @@ class BaseTable():
             df = df.join(
                 existing_sdf,
                 how="left_anti",
-                on=self.unique_columns,
+                on=self.unique_column_set,
             )
         if num_partitions is not None:
             df = df.repartition(num_partitions)

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -139,7 +139,12 @@ class BaseTable():
                 x for x in self.unique_column_set if x not in update_columns
             ]
         else:
-            update_columns = self.unique_column_set
+            logger.error(
+                "No update columns provided.  Cannot perform upsert."
+            )
+            raise ValueError(
+                "No update columns provided.  Cannot perform upsert."
+            )
 
         # Remove rows from existing_sdf that are to be updated.
         # Concat and re-write.

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -158,11 +158,14 @@ class BaseTable():
             # Get columns in correct order
             df = df.select([*self.schema_func().columns])
 
+        # Re-validate since the table was changed
+        validated_df = self._validate(df)
+
         if num_partitions is not None:
-            df = df.repartition(num_partitions)
+            validated_df = validated_df.repartition(num_partitions)
 
         (
-            df.
+            validated_df.
             write.
             partitionBy(partition_by).
             format(self.format).
@@ -199,10 +202,15 @@ class BaseTable():
                 how="left_anti",
                 on=self.unique_column_set,
             )
+
+        # Re-validate since the table was changed
+        validated_df = self._validate(df)
+
         if num_partitions is not None:
-            df = df.repartition(num_partitions)
+            validated_df = validated_df.repartition(num_partitions)
+
         (
-            df.
+            validated_df.
             write.
             partitionBy(partition_by).
             format(self.format).

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -274,20 +274,6 @@ class BaseTable():
             save(str(self.dir))
         )
 
-    def _check_for_null_partition_by_values(self, df: ps.DataFrame):
-        """Remove a field from partition_by if all values are null."""
-        partition_by = self.partition_by
-        if partition_by is None:
-            partition_by = []
-        for field_name in partition_by:
-            if field_name in df.columns:
-                if len(df.filter(df[field_name].isNotNull()).collect()) == 0:
-                    logger.debug(
-                        f"All {field_name} values are null. "
-                        f"{field_name} will be removed as a partition column."
-                    )
-                    self.partition_by.remove(field_name)
-
     def _check_for_null_unique_column_values(self, df: ps.DataFrame):
         """Remove a field from self.unique_column_set if all values are null."""
         for field_name in self.unique_column_set:
@@ -328,7 +314,6 @@ class BaseTable():
 
         if df is not None:
 
-            self._check_for_null_partition_by_values(df)
             self._check_for_null_unique_column_values(df)
 
             if write_mode == "overwrite":

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -252,17 +252,15 @@ class BaseTable():
                 "Nothing will be written."
             )
 
-    def _delete_and_write(
+    def _dynamic_overwrite(
         self,
         df: ps.DataFrame,
         **kwargs
     ):
-        """Delete all existing table data and write."""
+        """Overwrite partitions contained in the dataframe."""
         logger.info(
-            f"Deleting existing table data and writing to {self.name}."
+            f"Overwriting table partitions in {self.name}."
         )
-        # Deletes the entire directory first.
-        shutil.rmtree(str(self.dir))
         partition_by = self.partition_by
         if partition_by is None:
             partition_by = []
@@ -334,7 +332,7 @@ class BaseTable():
             self._check_for_null_unique_column_values(df)
 
             if write_mode == "overwrite":
-                self._delete_and_write(df, **kwargs)
+                self._dynamic_overwrite(df, **kwargs)
                 self._load_table()
             elif write_mode == "append":
                 self._append_without_duplicates(

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -138,6 +138,8 @@ class BaseTable():
             update_columns = [
                 x for x in self.unique_columns if x not in update_columns
             ]
+        else:
+            update_columns = self.unique_columns
 
         # Remove rows from existing_sdf that are to be updated.
         # Concat and re-write.

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -137,11 +137,12 @@ class BaseTable():
         # Limit the dataframe to the partitions that are being updated.
         # TODO: Make sure this works correctly with reference time.
         for partition in partition_by:
-            vals_to_check = df.select(partition).distinct(). \
+            partition_values = df.select(partition).distinct(). \
                 rdd.flatMap(lambda x: x).collect()
-            existing_sdf = existing_sdf.filter(
-                col(partition).isin(vals_to_check)
-            )
+            if partition_values[0] is not None:  # null reference time
+                existing_sdf = existing_sdf.filter(
+                    col(partition).isin(partition_values)
+                )
 
         # Remove rows from existing_sdf that are to be updated.
         # Concat and re-write.

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -49,6 +49,7 @@ class BaseTable():
             path: Union[str, Path, S3Path],
             pattern: str = None,
             use_table_schema: bool = False,
+            show_missing_table_warning: bool = True,
             **options
     ) -> ps.DataFrame:
         """Read data from table directory as a spark dataframe.
@@ -63,6 +64,9 @@ class BaseTable():
             If True, use the table schema to read the files.
             Missing files will be ignored with 'ignoreMissingFiles'
             set to True (default).
+        show_missing_table_warning : bool, optional
+            If True, show the warning an empty table was returned.
+            The default is True.
         **options
             Additional options to pass to the spark read method.
 
@@ -85,7 +89,7 @@ class BaseTable():
         if use_table_schema is True:
             schema = self.schema_func().to_structtype()
             df = self.ev.spark.read.format(self.format).options(**options).load(path, schema=schema)
-            if len(df.head(1)) == 0:
+            if len(df.head(1)) == 0 and show_missing_table_warning:
                 logger.warning(f"An empty dataframe was returned for '{self.name}'.")
         else:
             df = self.ev.spark.read.format(self.format).options(**options).load(path)
@@ -131,6 +135,7 @@ class BaseTable():
         existing_sdf = self._read_files(
             self.dir,
             use_table_schema=True,
+            show_missing_table_warning=False,
             **kwargs
         )
 
@@ -187,6 +192,7 @@ class BaseTable():
         existing_sdf = self._read_files(
             self.dir,
             use_table_schema=True,
+            show_missing_table_warning=False,
             **kwargs
         )
         # Anti-join: Joins rows from left df that do not have a match

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -127,18 +127,21 @@ class BaseTable():
         if partition_by is None:
             partition_by = []
 
-        existing_sdf = self._read_files(
-            self.dir,
-            use_table_schema=True,
-            **kwargs
-        )
+        if self.name != "joined_timeseries":
 
-        df = df.select(*existing_sdf.columns)
+            existing_sdf = self._read_files(
+                self.dir,
+                use_table_schema=True,
+                **kwargs
+            )
 
-        if not existing_sdf.isEmpty():
-            df = df.union(existing_sdf)
-            df = df.dropDuplicates(self.schema_func().unique)
-            pass
+            df = df.select(*existing_sdf.columns)
+
+            if not existing_sdf.isEmpty():
+                df = df.union(existing_sdf)
+                # df = df.dropDuplicates(self.schema_func().unique)
+                df = df.dropDuplicates()  # do we need to define a subset?
+                pass
 
         (
             df.

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -122,7 +122,7 @@ class BaseTable():
     ):
         """Drop duplicates and rewrite the table if duplicates exist."""
         logger.info(
-            f"Dropping potential duplicates from {self.name} and appending."
+            f"Dropping potential duplicates from {self.name} and upserting."
         )
         partition_by = self.partition_by
         if partition_by is None:

--- a/src/teehr/evaluation/tables/configuration_table.py
+++ b/src/teehr/evaluation/tables/configuration_table.py
@@ -14,10 +14,13 @@ class ConfigurationTable(DomainTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "configurations"
-        # self.dir = ev.configurations_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = ConfigurationFilter
         self.schema_func = schemas.configuration_schema
+        self.unique_columns = [
+            "name",
+            "type"
+        ]
 
     def field_enum(self) -> ConfigurationFields:
         """Get the configuration fields enum."""

--- a/src/teehr/evaluation/tables/configuration_table.py
+++ b/src/teehr/evaluation/tables/configuration_table.py
@@ -17,7 +17,7 @@ class ConfigurationTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = ConfigurationFilter
         self.schema_func = schemas.configuration_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "name",
             "type"
         ]

--- a/src/teehr/evaluation/tables/configuration_table.py
+++ b/src/teehr/evaluation/tables/configuration_table.py
@@ -17,10 +17,7 @@ class ConfigurationTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = ConfigurationFilter
         self.schema_func = schemas.configuration_schema
-        self.unique_column_set = [
-            "name",
-            "type"
-        ]
+        self.unique_column_set = ["name"]
 
     def field_enum(self) -> ConfigurationFields:
         """Get the configuration fields enum."""

--- a/src/teehr/evaluation/tables/domain_table.py
+++ b/src/teehr/evaluation/tables/domain_table.py
@@ -14,7 +14,7 @@ class DomainTable(BaseTable):
         """Initialize class."""
         super().__init__(ev)
         self.format = "csv"
-        self.save_mode = "overwrite"
+        self.save_mode = "append"
 
     def _add(
         self,

--- a/src/teehr/evaluation/tables/domain_table.py
+++ b/src/teehr/evaluation/tables/domain_table.py
@@ -14,7 +14,6 @@ class DomainTable(BaseTable):
         """Initialize class."""
         super().__init__(ev)
         self.format = "csv"
-        self.save_mode = "append"
 
     def _add(
         self,

--- a/src/teehr/evaluation/tables/joined_timeseries_table.py
+++ b/src/teehr/evaluation/tables/joined_timeseries_table.py
@@ -21,12 +21,12 @@ class JoinedTimeseriesTable(TimeseriesTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "joined_timeseries"
-        # self.dir = ev.joined_timeseries_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = JoinedTimeseriesFilter
         self.validate_filter_field_types = False
         self.strict_validation = False
         self.schema_func = schemas.joined_timeseries_schema
+        self.save_mode = "overwrite"
 
     def field_enum(self) -> JoinedTimeseriesFields:
         """Get the joined timeseries fields enum."""

--- a/src/teehr/evaluation/tables/joined_timeseries_table.py
+++ b/src/teehr/evaluation/tables/joined_timeseries_table.py
@@ -26,6 +26,14 @@ class JoinedTimeseriesTable(TimeseriesTable):
         self.validate_filter_field_types = False
         self.strict_validation = False
         self.schema_func = schemas.joined_timeseries_schema
+        self.unique_column_set = [
+            "primary_location_id",
+            "secondary_location_id",
+            "value_time",
+            "reference_time",
+            "variable_name",
+            "unit_name",
+        ]
 
     def field_enum(self) -> JoinedTimeseriesFields:
         """Get the joined timeseries fields enum."""
@@ -141,19 +149,7 @@ class JoinedTimeseriesTable(TimeseriesTable):
         return self
 
     def write(self, write_mode: TableWriteEnum = "overwrite"):
-        """Write the joined timeseries table to disk.
-
-        Parameters
-        ----------
-        write_mode : TableWriteEnum, optional (default: "overwrite")
-            The write mode for the table.
-            Options are "append", "upsert", and "overwrite".
-            If "append", the table will be appended with new data that does
-            already exist.
-            If "upsert", existing data will be replaced and new data that
-            does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
-        """
+        """Write the joined timeseries table to disk."""
         self._write_spark_df(self.df, write_mode=write_mode)
         logger.info("Joined timeseries table written to disk.")
         self._load_table()
@@ -194,7 +190,8 @@ class JoinedTimeseriesTable(TimeseriesTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are
+            overwritten.
         """
         joined_df = self._join()
 

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -27,7 +27,6 @@ class LocationAttributeTable(BaseTable):
         self.name = "location_attributes"
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.format = "parquet"
-        self.save_mode = "append"
         self.filter_model = LocationAttributeFilter
         self.schema_func = schemas.location_attributes_schema
         self.unique_column_set = [
@@ -147,11 +146,13 @@ class LocationAttributeTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
@@ -200,11 +201,13 @@ class LocationAttributeTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -22,12 +22,15 @@ class LocationAttributeTable(BaseTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "location_attributes"
-        # self.dir = ev.location_attributes_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.format = "parquet"
-        self.save_mode = "overwrite"
+        self.save_mode = "append"
         self.filter_model = LocationAttributeFilter
         self.schema_func = schemas.location_attributes_schema
+        self.unique_columns = [
+            "location_id",
+            "attribute_name"
+        ]
 
     def _load(
         self,

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -152,7 +152,8 @@ class LocationAttributeTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are
+            overwritten.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
@@ -207,7 +208,7 @@ class LocationAttributeTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are overwritten
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -27,7 +27,7 @@ class LocationAttributeTable(BaseTable):
         self.save_mode = "append"
         self.filter_model = LocationAttributeFilter
         self.schema_func = schemas.location_attributes_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "location_id",
             "attribute_name"
         ]

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -63,7 +63,10 @@ class LocationAttributeTable(BaseTable):
         validated_df = self._validate(df)
 
         # Write to the table df.rdd.getNumPartitions()
-        self._write_spark_df(validated_df.repartition(df.rdd.getNumPartitions()))
+        self._write_spark_df(
+            df=validated_df,
+            num_partitions=df.rdd.getNumPartitions()
+        )
 
         # Reload the table
         self._load_table()

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -1,3 +1,4 @@
+"""Location Attribute Table class."""
 import teehr.const as const
 from teehr.evaluation.tables.base_table import BaseTable
 from teehr.loading.location_attributes import convert_location_attributes
@@ -10,6 +11,8 @@ from pathlib import Path
 from typing import Union
 import logging
 from teehr.utils.utils import to_path_or_s3path, remove_dir_if_exists
+from teehr.loading.utils import add_or_replace_sdf_column_prefix
+from teehr.models.table_enums import TableWriteEnum
 
 
 logger = logging.getLogger(__name__)
@@ -37,6 +40,8 @@ class LocationAttributeTable(BaseTable):
         in_path: Union[Path, str],
         pattern: str = None,
         field_mapping: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Load location attributes helper."""
@@ -59,13 +64,22 @@ class LocationAttributeTable(BaseTable):
         # Read the converted files to Spark DataFrame
         df = self._read_files(cache_dir)
 
+        # Add or replace location_id prefix if provided
+        if location_id_prefix:
+            df = add_or_replace_sdf_column_prefix(
+                sdf=df,
+                column_name="location_id",
+                prefix=location_id_prefix,
+            )
+
         # Validate using the validate method
         validated_df = self._validate(df)
 
         # Write to the table df.rdd.getNumPartitions()
         self._write_spark_df(
             df=validated_df,
-            num_partitions=df.rdd.getNumPartitions()
+            num_partitions=df.rdd.getNumPartitions(),
+            write_mode=write_mode
         )
 
         # Reload the table
@@ -102,13 +116,18 @@ class LocationAttributeTable(BaseTable):
 
         location_ids = self.ev.locations.distinct_values("id")
         attr_names = self.ev.attributes.distinct_values("name")
-        return self.schema_func(location_ids=location_ids, attr_names=attr_names)
+        return self.schema_func(
+            location_ids=location_ids,
+            attr_names=attr_names
+        )
 
     def load_parquet(
         self,
         in_path: Union[Path, str],
         pattern: str = "**/*.parquet",
         field_mapping: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Import location_attributes from parquet file format.
@@ -121,12 +140,23 @@ class LocationAttributeTable(BaseTable):
         field_mapping : dict, optional
             A dictionary mapping input fields to output fields.
             Format: {input_field: output_field}
+        location_id_prefix : str, optional
+            The prefix to add to location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        write_mode : TableWriteEnum, optional (default: "append")
+            The write mode for the table. Options are "append" or "upsert".
+            If "append", the table will be appended with new data that does
+            already exist.
+            If "upsert", existing data will be replaced and new data that
+            does not exist will be appended.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
         Notes
         -----
-
         The TEEHR Location Attribute table schema includes fields:
 
         - location_id
@@ -138,6 +168,8 @@ class LocationAttributeTable(BaseTable):
             in_path=in_path,
             pattern=pattern,
             field_mapping=field_mapping,
+            location_id_prefix=location_id_prefix,
+            write_mode=write_mode,
             **kwargs
         )
         self._load_table()
@@ -147,6 +179,8 @@ class LocationAttributeTable(BaseTable):
         in_path: Union[Path, str],
         pattern: str = "**/*.csv",
         field_mapping: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Import location_attributes from CSV file format.
@@ -159,12 +193,23 @@ class LocationAttributeTable(BaseTable):
         field_mapping : dict, optional
             A dictionary mapping input fields to output fields.
             Format: {input_field: output_field}
+        location_id_prefix : str, optional
+            The prefix to add to location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        write_mode : TableWriteEnum, optional (default: "append")
+            The write mode for the table. Options are "append" or "upsert".
+            If "append", the table will be appended with new data that does
+            already exist.
+            If "upsert", existing data will be replaced and new data that
+            does not exist will be appended.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
         Notes
         -----
-
         The TEEHR Location Attribute table schema includes fields:
 
         - location_id
@@ -176,6 +221,8 @@ class LocationAttributeTable(BaseTable):
             in_path=in_path,
             pattern=pattern,
             field_mapping=field_mapping,
+            location_id_prefix=location_id_prefix,
+            write_mode=write_mode,
             **kwargs
         )
         self._load_table()

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -27,7 +27,7 @@ class LocationCrosswalkTable(BaseTable):
         self.save_mode = "append"
         self.filter_model = LocationCrosswalkFilter
         self.schema_func = schemas.location_crosswalks_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "primary_location_id",
             "secondary_location_id"
         ]

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -167,7 +167,8 @@ class LocationCrosswalkTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are
+            overwritten.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv()
             or pd.read_parquet().
@@ -231,7 +232,7 @@ class LocationCrosswalkTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are overwritten
         **kwargs
             Additional keyword arguments are passed to pd.read_csv()
             or pd.read_parquet().

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -66,24 +66,24 @@ class LocationCrosswalkTable(BaseTable):
         # Read the converted files to Spark DataFrame
         df = self._read_files(cache_dir)
 
-        # Validate using the validate method
-        validated_df = self._validate(df)
-
         # Add or replace primary location_id prefix if provided
         if primary_location_id_prefix:
-            validated_df = add_or_replace_sdf_column_prefix(
-                sdf=validated_df,
+            df = add_or_replace_sdf_column_prefix(
+                sdf=df,
                 column_name="primary_location_id",
                 prefix=primary_location_id_prefix,
             )
 
         # Add or replace secondary location_id prefix if provided
         if secondary_location_id_prefix:
-            validated_df = add_or_replace_sdf_column_prefix(
-                sdf=validated_df,
+            df = add_or_replace_sdf_column_prefix(
+                sdf=df,
                 column_name="secondary_location_id",
                 prefix=secondary_location_id_prefix,
             )
+
+        # Validate using the validate method
+        validated_df = self._validate(df)
 
         # Write to the table df.rdd.getNumPartitions()
         self._write_spark_df(

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -26,7 +26,6 @@ class LocationCrosswalkTable(BaseTable):
         self.name = "location_crosswalks"
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.format = "parquet"
-        self.save_mode = "append"
         self.filter_model = LocationCrosswalkFilter
         self.schema_func = schemas.location_crosswalks_schema
         self.unique_column_set = [
@@ -162,11 +161,13 @@ class LocationCrosswalkTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv()
             or pd.read_parquet().
@@ -224,11 +225,13 @@ class LocationCrosswalkTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv()
             or pd.read_parquet().

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -42,7 +42,6 @@ class LocationCrosswalkTable(BaseTable):
         primary_location_id_prefix: str = None,
         secondary_location_id_prefix: str = None,
         write_mode: TableWriteEnum = "append",
-        update_columns: list[str] = None,
         **kwargs
     ):
         """Load location crosswalks helper."""
@@ -90,7 +89,6 @@ class LocationCrosswalkTable(BaseTable):
             df=validated_df,
             num_partitions=df.rdd.getNumPartitions(),
             write_mode=write_mode,
-            update_columns=update_columns
         )
 
         # Reload the table
@@ -139,7 +137,6 @@ class LocationCrosswalkTable(BaseTable):
         primary_location_id_prefix: str = None,
         secondary_location_id_prefix: str = None,
         write_mode: TableWriteEnum = "append",
-        update_columns: list[str] = None,
         **kwargs
     ):
         """Import location crosswalks from parquet file format.
@@ -164,9 +161,6 @@ class LocationCrosswalkTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-        update_columns : list[str], optional
-            When ``write_mode`` is "upsert", the names of columns containing
-            data to be updated.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv()
             or pd.read_parquet().
@@ -187,7 +181,6 @@ class LocationCrosswalkTable(BaseTable):
             primary_location_id_prefix=primary_location_id_prefix,
             secondary_location_id_prefix=secondary_location_id_prefix,
             write_mode=write_mode,
-            update_columns=update_columns,
             **kwargs
         )
         self._load_table()
@@ -200,7 +193,6 @@ class LocationCrosswalkTable(BaseTable):
         primary_location_id_prefix: str = None,
         secondary_location_id_prefix: str = None,
         write_mode: TableWriteEnum = "append",
-        update_columns: list[str] = None,
         **kwargs
     ):
         """Import location crosswalks from CSV file format.
@@ -231,9 +223,6 @@ class LocationCrosswalkTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-        update_columns : list[str], optional
-            When ``write_mode`` is "upsert", the names of columns containing
-            data to be updated.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv()
             or pd.read_parquet().
@@ -253,7 +242,6 @@ class LocationCrosswalkTable(BaseTable):
             primary_location_id_prefix=primary_location_id_prefix,
             secondary_location_id_prefix=secondary_location_id_prefix,
             write_mode=write_mode,
-            update_columns=update_columns,
             **kwargs
         )
         self._load_table()

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -149,11 +149,17 @@ class LocationCrosswalkTable(BaseTable):
         field_mapping : dict, optional
             A dictionary mapping input fields to output fields.
             Format: {input_field: output_field}
-        location_id_prefix : str, optional
-            The prefix to add to location IDs.
+        primary_location_id_prefix : str, optional
+            The prefix to add to primary location IDs.
             Used to ensure unique location IDs across configurations.
-            Note, the methods for fetching USGS and NWM data expect
-            location IDs to be prefixed with "usgs" or the nwm version
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        secondary_location_id_prefix : str, optional
+            The prefix to add to secondary location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
             The write mode for the table. Options are "append" or "upsert".
@@ -206,16 +212,16 @@ class LocationCrosswalkTable(BaseTable):
             A dictionary mapping input fields to output fields.
             Format: {input_field: output_field}
         primary_location_id_prefix : str, optional
-            The prefix to add to the primary location IDs.
+            The prefix to add to primary location IDs.
             Used to ensure unique location IDs across configurations.
-            Note, the methods for fetching USGS and NWM data expect
-            location IDs to be prefixed with "usgs" or the nwm version
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         secondary_location_id_prefix : str, optional
-            The prefix to add to the secondary location IDs.
+            The prefix to add to secondary location IDs.
             Used to ensure unique location IDs across configurations.
-            Note, the methods for fetching USGS and NWM data expect
-            location IDs to be prefixed with "usgs" or the nwm version
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
             The write mode for the table. Options are "append" or "upsert".

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -64,7 +64,10 @@ class LocationCrosswalkTable(BaseTable):
         validated_df = self._validate(df)
 
         # Write to the table df.rdd.getNumPartitions()
-        self._write_spark_df(validated_df.repartition(df.rdd.getNumPartitions()))
+        self._write_spark_df(
+            df=validated_df,
+            num_partitions=df.rdd.getNumPartitions()
+        )
 
         # Reload the table
         self._load_table()

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -22,12 +22,15 @@ class LocationCrosswalkTable(BaseTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "location_crosswalks"
-        # self.dir = ev.location_crosswalks_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.format = "parquet"
-        self.save_mode = "overwrite"
+        self.save_mode = "append"
         self.filter_model = LocationCrosswalkFilter
         self.schema_func = schemas.location_crosswalks_schema
+        self.unique_columns = [
+            "primary_location_id",
+            "secondary_location_id"
+        ]
 
     def _load(
         self,

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -83,7 +83,7 @@ class LocationTable(BaseTable):
             Only used when in_path is a directory.
         location_id_prefix : str, optional
             The prefix to add to location IDs.
-            Used to ensure unique location IDs.
+            Used to ensure unique location IDs across configurations.
         write_mode : TableWriteEnum, optional (default: "append")
             The write mode for the table. Options are "append" or "upsert".
             If "append", the table will be appended with new data that does
@@ -139,9 +139,10 @@ class LocationTable(BaseTable):
 
         # Write to the table
         self._write_spark_df(
-            validated_df.repartition(1),
+            validated_df,
             write_mode=write_mode,
             update_columns=update_columns,
+            num_partitions=1
         )
 
         # Reload the table

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -1,3 +1,4 @@
+"""Location table class."""
 import teehr.const as const
 from teehr.evaluation.tables.base_table import BaseTable
 from teehr.loading.locations import convert_locations
@@ -79,8 +80,8 @@ class LocationTable(BaseTable):
         location_id_prefix : str, optional
             The prefix to add to location IDs.
             Used to ensure unique location IDs across configurations.
-            Note, the methods for fetching USGS and NWM data expect
-            location IDs to be prefixed with "usgs" or the nwm version
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
             The write mode for the table. Options are "append" or "upsert".
@@ -126,16 +127,16 @@ class LocationTable(BaseTable):
         # Read the converted files to Spark DataFrame
         df = self._read_files(cache_dir)
 
-        # Validate using the validate method
-        validated_df = self._validate(df)
-
         # Add or replace location_id prefix if provided
         if location_id_prefix:
             validated_df = add_or_replace_sdf_column_prefix(
-                sdf=validated_df,
+                sdf=df,
                 column_name="id",
                 prefix=location_id_prefix,
             )
+
+        # Validate using the validate method
+        validated_df = self._validate(df)
 
         # Write to the table
         self._write_spark_df(

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -26,7 +26,6 @@ class LocationTable(BaseTable):
         self.name = "locations"
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.format = "parquet"
-        self.save_mode = "append"
         self.filter_model = LocationFilter
         self.schema_func = schemas.locations_schema
         self.unique_column_set = ["id"]
@@ -84,11 +83,13 @@ class LocationTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to GeoPandas read_file().
 

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -28,7 +28,7 @@ class LocationTable(BaseTable):
         self.save_mode = "append"
         self.filter_model = LocationFilter
         self.schema_func = schemas.locations_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "id",
             "name",
             "geometry",

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -84,6 +84,9 @@ class LocationTable(BaseTable):
         location_id_prefix : str, optional
             The prefix to add to location IDs.
             Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data expect
+            location IDs to be prefixed with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
             The write mode for the table. Options are "append" or "upsert".
             If "append", the table will be appended with new data that does
@@ -106,6 +109,11 @@ class LocationTable(BaseTable):
         - id
         - name
         - geometry
+
+        ..note::
+          The methods for fetching USGS and NWM data expect
+          location IDs to be prefixed with "usgs" or the nwm version
+          ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         """
         cache_dir = Path(
             self.ev.dir_path,

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -28,11 +28,7 @@ class LocationTable(BaseTable):
         self.save_mode = "append"
         self.filter_model = LocationFilter
         self.schema_func = schemas.locations_schema
-        self.unique_column_set = [
-            "id",
-            "name",
-            "geometry",
-        ]
+        self.unique_column_set = ["id"]
 
     def field_enum(self) -> LocationFields:
         """Get the location fields enum."""
@@ -65,7 +61,6 @@ class LocationTable(BaseTable):
         pattern: str = "**/*.parquet",
         location_id_prefix: str = None,
         write_mode: TableWriteEnum = "append",
-        update_columns: list[str] = None,
         **kwargs
     ):
         """Import geometry data.
@@ -93,9 +88,6 @@ class LocationTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-        update_columns : list[str], optional
-            When ``write_mode`` is "upsert", the names of columns containing
-            data to be updated.
         **kwargs
             Additional keyword arguments are passed to GeoPandas read_file().
 
@@ -147,10 +139,9 @@ class LocationTable(BaseTable):
 
         # Write to the table
         self._write_spark_df(
-            validated_df,
+            df=validated_df,
             write_mode=write_mode,
-            update_columns=update_columns,
-            num_partitions=1
+            num_partitions=1,
         )
 
         # Reload the table

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -137,7 +137,7 @@ class LocationTable(BaseTable):
         # Validate using the validate method
         validated_df = self._validate(df)
 
-        # Add location_id prefix if provided
+        # Add or replace location_id prefix if provided
         if location_id_prefix:
             validated_df = add_or_replace_sdf_column_prefix(
                 sdf=validated_df,

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -89,7 +89,8 @@ class LocationTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are
+            overwritten.
         **kwargs
             Additional keyword arguments are passed to GeoPandas read_file().
 

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -129,7 +129,7 @@ class LocationTable(BaseTable):
 
         # Add or replace location_id prefix if provided
         if location_id_prefix:
-            validated_df = add_or_replace_sdf_column_prefix(
+            df = add_or_replace_sdf_column_prefix(
                 sdf=df,
                 column_name="id",
                 prefix=location_id_prefix,

--- a/src/teehr/evaluation/tables/primary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/primary_timeseries_table.py
@@ -84,7 +84,7 @@ class PrimaryTimeseriesTable(TimeseriesTable):
 
         # Add or replace location_id prefix if provided
         if location_id_prefix:
-            validated_df = add_or_replace_sdf_column_prefix(
+            df = add_or_replace_sdf_column_prefix(
                 sdf=df,
                 column_name="location_id",
                 prefix=location_id_prefix,

--- a/src/teehr/evaluation/tables/primary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/primary_timeseries_table.py
@@ -19,7 +19,6 @@ class PrimaryTimeseriesTable(TimeseriesTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "primary_timeseries"
-        # self.dir = ev.primary_timeseries_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.schema_func = schemas.primary_timeseries_schema
 

--- a/src/teehr/evaluation/tables/secondary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/secondary_timeseries_table.py
@@ -19,7 +19,6 @@ class SecondaryTimeseriesTable(TimeseriesTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "secondary_timeseries"
-        # self.dir = ev.secondary_timeseries_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.schema_func = schemas.secondary_timeseries_schema
 

--- a/src/teehr/evaluation/tables/secondary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/secondary_timeseries_table.py
@@ -24,6 +24,14 @@ class SecondaryTimeseriesTable(TimeseriesTable):
         self.name = "secondary_timeseries"
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.schema_func = schemas.secondary_timeseries_schema
+        self.unique_column_set = [
+            "location_id",
+            "value_time",
+            "reference_time",
+            "variable_name",
+            "unit_name",
+            "member"
+        ]
 
     def field_enum(self) -> TimeseriesFields:
         """Get the timeseries fields enum."""

--- a/src/teehr/evaluation/tables/secondary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/secondary_timeseries_table.py
@@ -92,7 +92,7 @@ class SecondaryTimeseriesTable(TimeseriesTable):
 
         # Add or replace location_id prefix if provided
         if location_id_prefix:
-            validated_df = add_or_replace_sdf_column_prefix(
+            df = add_or_replace_sdf_column_prefix(
                 sdf=df,
                 column_name="location_id",
                 prefix=location_id_prefix,

--- a/src/teehr/evaluation/tables/secondary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/secondary_timeseries_table.py
@@ -1,3 +1,4 @@
+"""Secondary timeseries table class."""
 import teehr.const as const
 from teehr.evaluation.tables.timeseries_table import TimeseriesTable
 from teehr.loading.timeseries import convert_timeseries
@@ -7,6 +8,8 @@ from pathlib import Path
 from typing import Union
 import logging
 from teehr.utils.utils import to_path_or_s3path, remove_dir_if_exists
+from teehr.models.table_enums import TableWriteEnum
+from teehr.loading.utils import add_or_replace_sdf_column_prefix
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +38,7 @@ class SecondaryTimeseriesTable(TimeseriesTable):
         if type == "pandas":
             return self.schema_func(type="pandas")
 
-        location_ids = self.ev.location_crosswalks.distinct_values("secondary_location_id")
+        location_ids = self.ev.location_crosswalks.distinct_values("secondary_location_id")  # noqa
         variable_names = self.ev.variables.distinct_values("name")
         configuration_names = self.ev.configurations.distinct_values("name")
         unit_names = self.ev.units.distinct_values("name")
@@ -52,6 +55,8 @@ class SecondaryTimeseriesTable(TimeseriesTable):
         pattern="**/*.parquet",
         field_mapping: dict = None,
         constant_field_values: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Import timeseries helper."""
@@ -77,11 +82,19 @@ class SecondaryTimeseriesTable(TimeseriesTable):
         # Read the converted files to Spark DataFrame
         df = self._read_files(cache_dir)
 
+        # Add or replace location_id prefix if provided
+        if location_id_prefix:
+            validated_df = add_or_replace_sdf_column_prefix(
+                sdf=df,
+                column_name="location_id",
+                prefix=location_id_prefix,
+            )
+
         # Validate using the _validate() method
         validated_df = self._validate(df)
 
         # Write to the table
-        self._write_spark_df(validated_df)
+        self._write_spark_df(validated_df, write_mode=write_mode)
 
         # Reload the table
         self._load_table()

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -26,13 +26,21 @@ class TimeseriesTable(BaseTable):
         """Initialize class."""
         super().__init__(ev)
         self.format = "parquet"
-        self.save_mode = "overwrite"
+        self.save_mode = "append"
         self.partition_by = [
             "configuration_name",
             "variable_name",
             "reference_time"
         ]
         self.filter_model = TimeseriesFilter
+        self.unique_columns = [
+            "reference_time",
+            "location_id",
+            "value_time",
+            "value",
+            "variable_name",
+            "configuration_name"
+        ]
 
     def to_pandas(self):
         """Return Pandas DataFrame for Primary Timeseries."""

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -25,7 +25,6 @@ class TimeseriesTable(BaseTable):
         """Initialize class."""
         super().__init__(ev)
         self.format = "parquet"
-        self.save_mode = "append"
         self.partition_by = [
             "configuration_name",
             "variable_name",
@@ -83,11 +82,13 @@ class TimeseriesTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
@@ -149,11 +150,13 @@ class TimeseriesTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv().
 
@@ -215,11 +218,13 @@ class TimeseriesTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
         **kwargs
             Additional keyword arguments are passed to xr.open_dataset().
 
@@ -300,11 +305,13 @@ class TimeseriesTable(BaseTable):
             prefix location IDs with "usgs" or the nwm version
             ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
         write_mode : TableWriteEnum, optional (default: "append")
-            The write mode for the table. Options are "append" or "upsert".
+            The write mode for the table.
+            Options are "append", "upsert", and "overwrite".
             If "append", the table will be appended with new data that does
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
+            If "overwrite", all data is deleted before new data is written.
 
         Includes validation and importing data to database.
 

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -27,7 +27,11 @@ class TimeseriesTable(BaseTable):
         super().__init__(ev)
         self.format = "parquet"
         self.save_mode = "overwrite"
-        self.partition_by = ["configuration_name", "variable_name"]
+        self.partition_by = [
+            "configuration_name",
+            "variable_name",
+            "reference_time"
+        ]
         self.filter_model = TimeseriesFilter
 
     def to_pandas(self):

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -34,12 +34,10 @@ class TimeseriesTable(BaseTable):
         ]
         self.filter_model = TimeseriesFilter
         self.unique_column_set = [
-            "reference_time",
             "location_id",
             "value_time",
-            "value",
             "variable_name",
-            "configuration_name"
+            "unit_name",
         ]
 
     def to_pandas(self):

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -88,7 +88,8 @@ class TimeseriesTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are
+            overwritten.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
@@ -156,7 +157,7 @@ class TimeseriesTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are overwritten
         **kwargs
             Additional keyword arguments are passed to pd.read_csv().
 
@@ -224,7 +225,7 @@ class TimeseriesTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are overwritten
         **kwargs
             Additional keyword arguments are passed to xr.open_dataset().
 
@@ -311,7 +312,7 @@ class TimeseriesTable(BaseTable):
             already exist.
             If "upsert", existing data will be replaced and new data that
             does not exist will be appended.
-            If "overwrite", all data is deleted before new data is written.
+            If "overwrite", existing partitions receiving new data are overwritten
 
         Includes validation and importing data to database.
 

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -33,7 +33,7 @@ class TimeseriesTable(BaseTable):
             "reference_time"
         ]
         self.filter_model = TimeseriesFilter
-        self.unique_columns = [
+        self.unique_column_set = [
             "reference_time",
             "location_id",
             "value_time",

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -1,4 +1,4 @@
-import teehr.const as const
+"""Timeseries table base class."""
 from teehr.evaluation.tables.base_table import BaseTable
 from teehr.loading.utils import (
     validate_input_is_xml,
@@ -7,9 +7,8 @@ from teehr.loading.utils import (
     validate_input_is_parquet
 )
 from teehr.models.filters import TimeseriesFilter
-# from teehr.models.table_enums import TimeseriesFields
-# from teehr.models.pydantic_table_models import Timeseries
 from teehr.querying.utils import join_geometry
+from teehr.models.table_enums import TableWriteEnum
 
 from pathlib import Path
 from typing import Union
@@ -59,6 +58,8 @@ class TimeseriesTable(BaseTable):
         pattern: str = "**/*.parquet",
         field_mapping: dict = None,
         constant_field_values: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Import primary timeseries parquet data.
@@ -74,6 +75,18 @@ class TimeseriesTable(BaseTable):
         constant_field_values : dict, optional
             A dictionary mapping field names to constant values.
             Format: {field_name: value}
+        location_id_prefix : str, optional
+            The prefix to add to location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        write_mode : TableWriteEnum, optional (default: "append")
+            The write mode for the table. Options are "append" or "upsert".
+            If "append", the table will be appended with new data that does
+            already exist.
+            If "upsert", existing data will be replaced and new data that
+            does not exist will be appended.
         **kwargs
             Additional keyword arguments are passed to pd.read_parquet().
 
@@ -81,7 +94,6 @@ class TimeseriesTable(BaseTable):
 
         Notes
         -----
-
         The TEEHR Timeseries table schema includes fields:
 
         - reference_time
@@ -100,6 +112,8 @@ class TimeseriesTable(BaseTable):
             pattern=pattern,
             field_mapping=field_mapping,
             constant_field_values=constant_field_values,
+            location_id_prefix=location_id_prefix,
+            write_mode=write_mode,
             **kwargs
         )
         self._load_table()
@@ -110,6 +124,8 @@ class TimeseriesTable(BaseTable):
         pattern: str = "**/*.csv",
         field_mapping: dict = None,
         constant_field_values: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Import primary timeseries csv data.
@@ -125,6 +141,18 @@ class TimeseriesTable(BaseTable):
         constant_field_values : dict, optional
             A dictionary mapping field names to constant values.
             Format: {field_name: value}
+        location_id_prefix : str, optional
+            The prefix to add to location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        write_mode : TableWriteEnum, optional (default: "append")
+            The write mode for the table. Options are "append" or "upsert".
+            If "append", the table will be appended with new data that does
+            already exist.
+            If "upsert", existing data will be replaced and new data that
+            does not exist will be appended.
         **kwargs
             Additional keyword arguments are passed to pd.read_csv().
 
@@ -132,7 +160,6 @@ class TimeseriesTable(BaseTable):
 
         Notes
         -----
-
         The TEEHR Timeseries table schema includes fields:
 
         - reference_time
@@ -151,6 +178,8 @@ class TimeseriesTable(BaseTable):
             pattern=pattern,
             field_mapping=field_mapping,
             constant_field_values=constant_field_values,
+            location_id_prefix=location_id_prefix,
+            write_mode=write_mode,
             **kwargs
         )
         self._load_table()
@@ -161,6 +190,8 @@ class TimeseriesTable(BaseTable):
         pattern: str = "**/*.nc",
         field_mapping: dict = None,
         constant_field_values: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
         **kwargs
     ):
         """Import primary timeseries netcdf data.
@@ -176,6 +207,18 @@ class TimeseriesTable(BaseTable):
         constant_field_values : dict, optional
             A dictionary mapping field names to constant values.
             Format: {field_name: value}
+        location_id_prefix : str, optional
+            The prefix to add to location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        write_mode : TableWriteEnum, optional (default: "append")
+            The write mode for the table. Options are "append" or "upsert".
+            If "append", the table will be appended with new data that does
+            already exist.
+            If "upsert", existing data will be replaced and new data that
+            does not exist will be appended.
         **kwargs
             Additional keyword arguments are passed to xr.open_dataset().
 
@@ -183,7 +226,6 @@ class TimeseriesTable(BaseTable):
 
         Notes
         -----
-
         The TEEHR Timeseries table schema includes fields:
 
         - reference_time
@@ -202,6 +244,8 @@ class TimeseriesTable(BaseTable):
             pattern=pattern,
             field_mapping=field_mapping,
             constant_field_values=constant_field_values,
+            location_id_prefix=location_id_prefix,
+            write_mode=write_mode,
             **kwargs
         )
         self._load_table()
@@ -220,6 +264,8 @@ class TimeseriesTable(BaseTable):
             "forecastDate": "reference_time"
         },
         constant_field_values: dict = None,
+        location_id_prefix: str = None,
+        write_mode: TableWriteEnum = "append",
     ):
         """Import timeseries from XML data format.
 
@@ -246,6 +292,18 @@ class TimeseriesTable(BaseTable):
         constant_field_values : dict, optional
             A dictionary mapping field names to constant values.
             Format: {field_name: value}.
+        location_id_prefix : str, optional
+            The prefix to add to location IDs.
+            Used to ensure unique location IDs across configurations.
+            Note, the methods for fetching USGS and NWM data automatically
+            prefix location IDs with "usgs" or the nwm version
+            ("nwm12, "nwm21", "nwm22", or "nwm30"), respectively.
+        write_mode : TableWriteEnum, optional (default: "append")
+            The write mode for the table. Options are "append" or "upsert".
+            If "append", the table will be appended with new data that does
+            already exist.
+            If "upsert", existing data will be replaced and new data that
+            does not exist will be appended.
 
         Includes validation and importing data to database.
 
@@ -277,5 +335,7 @@ class TimeseriesTable(BaseTable):
             pattern=pattern,
             field_mapping=field_mapping,
             constant_field_values=constant_field_values,
+            location_id_prefix=location_id_prefix,
+            write_mode=write_mode,
         )
         self._load_table()

--- a/src/teehr/evaluation/tables/timeseries_table.py
+++ b/src/teehr/evaluation/tables/timeseries_table.py
@@ -35,6 +35,7 @@ class TimeseriesTable(BaseTable):
         self.unique_column_set = [
             "location_id",
             "value_time",
+            "reference_time",
             "variable_name",
             "unit_name",
         ]

--- a/src/teehr/evaluation/tables/unit_table.py
+++ b/src/teehr/evaluation/tables/unit_table.py
@@ -21,7 +21,7 @@ class UnitTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = UnitFilter
         self.schema_func = schemas.unit_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "name",
             "long_name",
         ]

--- a/src/teehr/evaluation/tables/unit_table.py
+++ b/src/teehr/evaluation/tables/unit_table.py
@@ -18,10 +18,13 @@ class UnitTable(DomainTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "units"
-        # self.dir = ev.units_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = UnitFilter
         self.schema_func = schemas.unit_schema
+        self.unique_columns = [
+            "name",
+            "long_name",
+        ]
 
     def field_enum(self) -> UnitFields:
         """Get the unit fields enum."""

--- a/src/teehr/evaluation/tables/unit_table.py
+++ b/src/teehr/evaluation/tables/unit_table.py
@@ -21,10 +21,7 @@ class UnitTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = UnitFilter
         self.schema_func = schemas.unit_schema
-        self.unique_column_set = [
-            "name",
-            "long_name",
-        ]
+        self.unique_column_set = ["name"]
 
     def field_enum(self) -> UnitFields:
         """Get the unit fields enum."""

--- a/src/teehr/evaluation/tables/variable_table.py
+++ b/src/teehr/evaluation/tables/variable_table.py
@@ -21,10 +21,7 @@ class VariableTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = VariableFilter
         self.schema_func = schemas.variable_schema
-        self.unique_column_set = [
-            "name",
-            "long_name"
-        ]
+        self.unique_column_set = ["name"]
 
     def field_enum(self) -> VariableFields:
         """Get the variable fields enum."""

--- a/src/teehr/evaluation/tables/variable_table.py
+++ b/src/teehr/evaluation/tables/variable_table.py
@@ -18,10 +18,13 @@ class VariableTable(DomainTable):
         """Initialize class."""
         super().__init__(ev)
         self.name = "variables"
-        # self.dir = ev.variables_dir
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = VariableFilter
         self.schema_func = schemas.variable_schema
+        self.unique_columns = [
+            "name",
+            "long_name"
+        ]
 
     def field_enum(self) -> VariableFields:
         """Get the variable fields enum."""

--- a/src/teehr/evaluation/tables/variable_table.py
+++ b/src/teehr/evaluation/tables/variable_table.py
@@ -21,7 +21,7 @@ class VariableTable(DomainTable):
         self.dir = to_path_or_s3path(ev.dataset_dir, self.name)
         self.filter_model = VariableFilter
         self.schema_func = schemas.variable_schema
-        self.unique_columns = [
+        self.unique_column_set = [
             "name",
             "long_name"
         ]

--- a/src/teehr/examples/partition_by_reference_time.py
+++ b/src/teehr/examples/partition_by_reference_time.py
@@ -1,0 +1,152 @@
+"""A utility for rewriting Evaluations with reference time as a partition."""
+from pathlib import Path
+from typing import List
+import pyspark.sql as ps
+import shutil
+
+import teehr
+from teehr.utils.utils import remove_dir_if_exists
+
+PARTITION_BY = [
+    "configuration_name",
+    "variable_name",
+    "reference_time"
+]
+KWARGS = {
+    "header": "true",
+}
+
+
+def _check_for_null_reference_time(partition_by: List[str], sdf: ps.DataFrame):
+    """Check if the reference time column is all null."""
+    if "reference_time" in sdf.columns:
+        if len(sdf.filter(sdf.reference_time.isNotNull()).collect()) == 0:
+            if "reference_time" in partition_by:
+                partition_by.remove("reference_time")
+    return partition_by
+
+
+def rewrite_secondary_timeseries(
+    ev: teehr.Evaluation,
+    partition_by: List[str] = PARTITION_BY
+):
+    """Rewrite secondary timeseries partitioning on reference time."""
+    secondary_sdf = ev.secondary_timeseries.to_sdf()
+
+    partition_by = _check_for_null_reference_time(
+        partition_by,
+        secondary_sdf
+    )
+    temp_path = Path(
+        ev.cache_dir,
+        "temp_rewrite",
+        "secondary_timeseries"
+    )
+    (
+        secondary_sdf.
+        write.
+        partitionBy(partition_by).
+        format("parquet").
+        mode("overwrite").
+        options(**KWARGS).
+        save(str(temp_path))
+    )
+    # Copy in temp dir then remove
+    remove_dir_if_exists(ev.secondary_timeseries.dir)
+    shutil.copytree(
+        str(temp_path),
+        str(ev.secondary_timeseries.dir),
+        dirs_exist_ok=True
+    )
+    remove_dir_if_exists(Path(ev.cache_dir, "temp_rewrite"))
+
+
+def rewrite_primary_timeseries(
+    ev: teehr.Evaluation,
+    partition_by: List[str] = PARTITION_BY
+):
+    """Rewrite primary timeseries partitioning on reference time."""
+    primary_sdf = ev.primary_timeseries.to_sdf()
+
+    partition_by = _check_for_null_reference_time(
+        partition_by,
+        primary_sdf
+    )
+    temp_path = Path(
+        ev.cache_dir,
+        "temp_rewrite",
+        "primary_timeseries"
+    )
+    (
+        primary_sdf.
+        write.
+        partitionBy(partition_by).
+        format("parquet").
+        mode("overwrite").
+        options(**KWARGS).
+        save(str(temp_path))
+    )
+    # Copy in temp dir then remove
+    remove_dir_if_exists(ev.primary_timeseries.dir)
+    shutil.copytree(
+        str(temp_path),
+        str(ev.primary_timeseries.dir),
+        dirs_exist_ok=True
+    )
+    remove_dir_if_exists(Path(ev.cache_dir, "temp_rewrite"))
+
+
+def rewrite_joined_timeseries(
+    ev: teehr.Evaluation,
+    partition_by: List[str] = PARTITION_BY
+):
+    """Rewrite joined timeseries partitioning on reference time."""
+    joined_sdf = ev.joined_timeseries.to_sdf()
+
+    partition_by = _check_for_null_reference_time(
+        partition_by,
+        joined_sdf
+    )
+    temp_path = Path(
+        ev.cache_dir,
+        "temp_rewrite",
+        "joined_timeseries"
+    )
+    (
+        joined_sdf.
+        write.
+        partitionBy(partition_by).
+        format("parquet").
+        mode("overwrite").
+        options(**KWARGS).
+        save(str(temp_path))
+    )
+    # Copy in temp dir then remove
+    remove_dir_if_exists(ev.joined_timeseries.dir)
+    shutil.copytree(
+        str(temp_path),
+        str(ev.joined_timeseries.dir),
+        dirs_exist_ok=True
+    )
+    remove_dir_if_exists(Path(ev.cache_dir, "temp_rewrite"))
+
+
+if __name__ == "__main__":
+
+    # Define the path to your evaluation directory
+    test_eval_dir = Path("/mnt/data/ciroh/teehr/test_stuff/temp_repartition_ev/temp_ev")
+
+    # Create an Evaluation object and create the directory
+    ev = teehr.Evaluation(dir_path=test_eval_dir)
+
+    # Re-write the primary timeseries with reference time as a partition,
+    # if it is not null.
+    # This will overwrite the existing data in the directory.
+    rewrite_primary_timeseries(ev)
+
+    # Re-write the secondary timeseries with reference time as a partition,
+    # if it is not null.
+    # This will overwrite the existing data in the directory.
+    rewrite_secondary_timeseries(ev)
+
+    pass

--- a/src/teehr/examples/partition_by_reference_time.py
+++ b/src/teehr/examples/partition_by_reference_time.py
@@ -141,12 +141,14 @@ if __name__ == "__main__":
 
     # Re-write the primary timeseries with reference time as a partition,
     # if it is not null.
-    # This will overwrite the existing data in the directory.
     rewrite_primary_timeseries(ev)
 
     # Re-write the secondary timeseries with reference time as a partition,
     # if it is not null.
-    # This will overwrite the existing data in the directory.
     rewrite_secondary_timeseries(ev)
+
+    # Re-write the joined timeseries with reference time as a partition,
+    # if it is not null.
+    rewrite_joined_timeseries(ev)
 
     pass

--- a/src/teehr/loading/s3/clone_from_s3.py
+++ b/src/teehr/loading/s3/clone_from_s3.py
@@ -192,7 +192,7 @@ def clone_from_s3(
             end_date=end_date
         )
 
-        table._write_spark_df(sdf_in)
+        table._write_spark_df(sdf_in, write_mode="overwrite")
 
     # copy scripts path to ev.scripts_dir
     source = f"{url}/scripts/user_defined_fields.py"

--- a/src/teehr/loading/timeseries.py
+++ b/src/teehr/loading/timeseries.py
@@ -10,6 +10,7 @@ from teehr.loading.utils import (
     # convert_datetime_ns_to_ms
 )
 import teehr.models.pandera_dataframe_schemas as schemas
+from teehr.models.table_enums import TableWriteEnum
 
 import logging
 
@@ -203,6 +204,7 @@ def validate_and_insert_timeseries(
     in_path: Union[str, Path],
     timeseries_type: str,
     pattern: str = "**/*.parquet",
+    write_mode: TableWriteEnum = "append",
 ):
     """Validate and insert primary timeseries data.
 
@@ -217,6 +219,12 @@ def validate_and_insert_timeseries(
         Valid values: "primary", "secondary"
     pattern : str, optional (default: "**/*.parquet")
         The pattern to match files.
+    write_mode : TableWriteEnum, optional (default: "append")
+        The write mode for the table. Options are "append" or "upsert".
+        If "append", the Evaluation table will be appended with new data
+        that does not already exist.
+        If "upsert", existing data will be replaced and new data that
+        does not exist will be appended.
     """
     in_path = Path(in_path)
     logger.info(f"Validating and inserting timeseries data from {in_path}")
@@ -235,7 +243,10 @@ def validate_and_insert_timeseries(
     validated_df = table._validate(df)
 
     # Write to the table
-    table._write_spark_df(validated_df)
+    table._write_spark_df(
+        validated_df,
+        write_mode=write_mode
+    )
 
     # Reload the table
     table._load_table()

--- a/src/teehr/models/pandera_dataframe_schemas.py
+++ b/src/teehr/models/pandera_dataframe_schemas.py
@@ -275,7 +275,6 @@ def location_attributes_schema(
             },
             strict=True,
             coerce=True,
-            unique=["location_id", "attribute_name", "value"]
         )
 
 def location_crosswalks_schema(
@@ -312,7 +311,6 @@ def location_crosswalks_schema(
             },
             strict=True,
             coerce=True,
-            unique=["primary_location_id", "secondary_location_id"]
         )
 
 
@@ -338,7 +336,6 @@ def weights_file_schema() -> pa.DataFrameSchema:
             )
         },
         strict="filter",
-        unique=["row", "col", "weight", "location_id"],
         coerce=True
     )
 
@@ -438,15 +435,6 @@ def primary_timeseries_schema(
             },
             strict=True,
             coerce=True,
-            unique=[
-                "reference_time",
-                "value_time",
-                "value",
-                "variable_name",
-                "configuration_name",
-                "unit_name",
-                "location_id"
-            ]
         )
 
 
@@ -548,16 +536,6 @@ def secondary_timeseries_schema(
             },
             strict=True,
             coerce=True,
-            unique=[
-                "reference_time",
-                "value_time",
-                "value",
-                "variable_name",
-                "configuration_name",
-                "unit_name",
-                "location_id",
-                "member"
-            ]
         )
 
 def joined_timeseries_schema(
@@ -657,16 +635,4 @@ def joined_timeseries_schema(
                 )
             },
             coerce=True,
-            unique=[
-                "reference_time",
-                "value_time",
-                "primary_value",
-                "secondary_value",
-                "variable_name",
-                "configuration_name",
-                "unit_name",
-                "primary_location_id",
-                "secondary_location_id",
-                "member"
-            ]
         )

--- a/src/teehr/models/pandera_dataframe_schemas.py
+++ b/src/teehr/models/pandera_dataframe_schemas.py
@@ -274,7 +274,8 @@ def location_attributes_schema(
                 )
             },
             strict=True,
-            coerce=True
+            coerce=True,
+            unique=["location_id", "attribute_name", "value"]
         )
 
 def location_crosswalks_schema(
@@ -310,7 +311,8 @@ def location_crosswalks_schema(
                 )
             },
             strict=True,
-            coerce=True
+            coerce=True,
+            unique=["primary_location_id", "secondary_location_id"]
         )
 
 
@@ -321,25 +323,23 @@ def weights_file_schema() -> pa.DataFrameSchema:
             "row": pa.Column(
                 pa.Int32,
                 nullable=False,
-                coerce=True
             ),
             "col": pa.Column(
                 pa.Int32,
                 nullable=False,
-                coerce=True
             ),
             "weight": pa.Column(
                 pa.Float32,
                 nullable=False,
-                coerce=True
             ),
             "location_id": pa.Column(
                 pa.String,
                 nullable=False,
-                coerce=True
             )
         },
-        strict="filter"
+        strict="filter",
+        unique=["row", "col", "weight", "location_id"],
+        coerce=True
     )
 
 
@@ -437,7 +437,16 @@ def primary_timeseries_schema(
                 )
             },
             strict=True,
-            coerce=True
+            coerce=True,
+            unique=[
+                "reference_time",
+                "value_time",
+                "value",
+                "variable_name",
+                "configuration_name",
+                "unit_name",
+                "location_id"
+            ]
         )
 
 
@@ -493,7 +502,7 @@ def secondary_timeseries_schema(
             },
             strict="filter",
             coerce=True,
-            add_missing_columns=True
+            add_missing_columns=True,
         )
     if type == "pyspark":
         return ps.DataFrameSchema(
@@ -538,7 +547,17 @@ def secondary_timeseries_schema(
                 )
             },
             strict=True,
-            coerce=True
+            coerce=True,
+            unique=[
+                "reference_time",
+                "value_time",
+                "value",
+                "variable_name",
+                "configuration_name",
+                "unit_name",
+                "location_id",
+                "member"
+            ]
         )
 
 def joined_timeseries_schema(
@@ -637,5 +656,17 @@ def joined_timeseries_schema(
                     nullable=True
                 )
             },
-            coerce=True
+            coerce=True,
+            unique=[
+                "reference_time",
+                "value_time",
+                "primary_value",
+                "secondary_value",
+                "variable_name",
+                "configuration_name",
+                "unit_name",
+                "primary_location_id",
+                "secondary_location_id",
+                "member"
+            ]
         )

--- a/src/teehr/models/table_enums.py
+++ b/src/teehr/models/table_enums.py
@@ -7,6 +7,7 @@ class TableWriteEnum(StrEnum):
 
     append = "append"
     upsert = "upsert"
+    overwrite = "overwrite"
 
 
 class ConfigurationFields(StrEnum):

--- a/src/teehr/models/table_enums.py
+++ b/src/teehr/models/table_enums.py
@@ -2,6 +2,13 @@
 from teehr.models.str_enum import StrEnum
 
 
+class TableWriteEnum(StrEnum):
+    """Methods to write or update Evaluation tables."""
+
+    append = "append"
+    upsert = "upsert"
+
+
 class ConfigurationFields(StrEnum):
     """Empty class for ConfigurationFieldEnum."""
 

--- a/tests/data/test_study/timeseries/nwm_ana_timeseries_for_upsert.parquet
+++ b/tests/data/test_study/timeseries/nwm_ana_timeseries_for_upsert.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2428fe9f5009ffef58919c1c8d3b06b997ba2ee3761171f49ca419e7b4a06047
+size 7292

--- a/tests/data/v0_3_test_study/geo/extended_v03_gages.geojson
+++ b/tests/data/v0_3_test_study/geo/extended_v03_gages.geojson
@@ -1,0 +1,13 @@
+{
+"type": "FeatureCollection",
+"name": "extended_v03_gages",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "id": "gage-A", "name": "cool site A" }, "geometry": { "type": "Point", "coordinates": [ -80.719184317999975, 35.176113478111198 ] } },
+{ "type": "Feature", "properties": { "id": "gage-B", "name": "cool site B" }, "geometry": { "type": "Point", "coordinates": [ -80.71308451799996, 35.158390611111336 ] } },
+{ "type": "Feature", "properties": { "id": "gage-C", "name": "cool site C" }, "geometry": { "type": "Point", "coordinates": [ -80.736772517999952, 35.186932211111149 ] } },
+{ "type": "Feature", "properties": { "id": "gage-D", "name": "cool site D" }, "geometry": { "type": "Point", "coordinates": [ -80.719184317999975, 35.176113478111198 ] } },
+{ "type": "Feature", "properties": { "id": "gage-E", "name": "cool site E" }, "geometry": { "type": "Point", "coordinates": [ -80.71308451799996, 35.158390611111336 ] } },
+{ "type": "Feature", "properties": { "id": "gage-F", "name": "cool site F" }, "geometry": { "type": "Point", "coordinates": [ -80.736772517999952, 35.186932211111149 ] } }
+]
+}

--- a/tests/data/v0_3_test_study/geo/gages_no_prefix.geojson
+++ b/tests/data/v0_3_test_study/geo/gages_no_prefix.geojson
@@ -1,0 +1,10 @@
+{
+"type": "FeatureCollection",
+"name": "gages_no_prefix",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"features": [
+{ "type": "Feature", "properties": { "id": "A", "name": "Site A" }, "geometry": { "type": "Point", "coordinates": [ -80.719184317999975, 35.176113478111198 ] } },
+{ "type": "Feature", "properties": { "id": "B", "name": "Site B" }, "geometry": { "type": "Point", "coordinates": [ -80.71308451799996, 35.158390611111336 ] } },
+{ "type": "Feature", "properties": { "id": "C", "name": "Bite C" }, "geometry": { "type": "Point", "coordinates": [ -80.736772517999952, 35.186932211111149 ] } }
+]
+}

--- a/tests/data/v0_3_test_study/timeseries/test_short_obs_upsert.parquet
+++ b/tests/data/v0_3_test_study/timeseries/test_short_obs_upsert.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d611d36441ae952942387e51279a0d85313c43274b9c5dc88bd07acc0d09cd63
+size 6111

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -45,7 +45,7 @@ def test_fetch_and_load_nwm_retro_points(tmpdir):
 
     # Make sure second fetch succeeds.
     ev.fetch.usgs_streamflow(
-        start_date=datetime(2022, 2, 24),
+        start_date=datetime(2022, 2, 22),
         end_date=datetime(2022, 2, 25)
     )
 

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -153,6 +153,14 @@ def test_fetch_and_load_nwm_operational_points(tmpdir):
     )
     ts_df = ev.secondary_timeseries.to_pandas()
 
+    filepath = Path(
+        TEST_STUDY_DATA_DIR,
+        "timeseries",
+        "nwm_ana_timeseries_for_upsert.parquet"
+    )
+    ev.secondary_timeseries.load_parquet(in_path=filepath, write_mode="upsert")
+    updated_df = ev.secondary_timeseries.to_pandas()
+
     assert isinstance(ts_df, pd.DataFrame)
     assert set(ts_df.columns.tolist()) == set([
             "reference_time",
@@ -168,6 +176,10 @@ def test_fetch_and_load_nwm_operational_points(tmpdir):
     assert np.isclose(ts_df.value.sum(), np.float32(492.21))
     assert ts_df.value_time.min() == pd.Timestamp("2024-02-22 03:00:00")
     assert ts_df.value_time.max() == pd.Timestamp("2024-02-22 20:00:00")
+    assert updated_df.value_time.min() == pd.Timestamp("2024-02-22 03:00:00")
+    assert updated_df.value_time.max() == pd.Timestamp("2024-02-23 06:00:00")
+    assert np.isclose(updated_df.value.sum(), np.float32(492485.03))
+
 
 
 @pytest.mark.skip(reason="This takes forever!")

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -61,7 +61,6 @@ def test_fetch_and_load_nwm_retro_points(tmpdir):
         start_date=datetime(2022, 2, 22),
         end_date=datetime(2022, 2, 23)
     )
-    ts_df = ev.secondary_timeseries.to_pandas()
 
     # Make sure second fetch succeeds.
     ev.fetch.nwm_retrospective_points(
@@ -71,10 +70,12 @@ def test_fetch_and_load_nwm_retro_points(tmpdir):
         end_date=datetime(2022, 2, 25)
     )
 
+    sts_df = ev.secondary_timeseries.to_pandas()
+
     assert pts_df.value_time.min() == pd.Timestamp("2022-02-22 00:00:00")
     assert pts_df.value_time.max() == pd.Timestamp("2022-02-25 00:00:00")
-    assert isinstance(ts_df, pd.DataFrame)
-    assert set(ts_df.columns.tolist()) == set([
+    assert isinstance(sts_df, pd.DataFrame)
+    assert set(sts_df.columns.tolist()) == set([
             "reference_time",
             "value_time",
             "value",
@@ -84,10 +85,10 @@ def test_fetch_and_load_nwm_retro_points(tmpdir):
             "variable_name",
             "member"
             ])
-    assert ts_df.unit_name.iloc[0] == "m^3/s"
-    assert np.isclose(ts_df.value.sum(), np.float32(7319.99))
-    assert ts_df.value_time.min() == pd.Timestamp("2022-02-22 00:00:00")
-    assert ts_df.value_time.max() == pd.Timestamp("2022-02-23 23:00:00")
+    assert sts_df.unit_name.iloc[0] == "m^3/s"
+    assert np.isclose(sts_df.value.sum(), np.float32(14570.21))
+    assert sts_df.value_time.min() == pd.Timestamp("2022-02-22 00:00:00")
+    assert sts_df.value_time.max() == pd.Timestamp("2022-02-25 23:00:00")
 
 
 def test_fetch_and_load_nwm_retro_grids(tmpdir):

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -215,9 +215,9 @@ def test_fetch_and_load_nwm_operational_grids(tmpdir):
             "primary_timeseries",
             "configuration_name=nwm30_forcing_analysis_assim",
             "variable_name=rainfall_hourly_rate"
-            ).glob("*.parquet")
+            ).rglob("*.parquet")
     )
-    assert len(file_list) == 7
+    assert len(file_list) == 21
 
 
 if __name__ == "__main__":

--- a/tests/test_import_location_attributes.py
+++ b/tests/test_import_location_attributes.py
@@ -36,7 +36,8 @@ def test_validate_and_insert_location_attributes(tmpdir):
     ev.enable_logging()
 
     ev.locations.load_spatial(
-        in_path=GEOJSON_GAGES_FILEPATH
+        in_path=GEOJSON_GAGES_FILEPATH,
+        location_id_prefix="usgs"
     )
     ev.attributes.add(
         [
@@ -61,6 +62,7 @@ def test_validate_and_insert_location_attributes(tmpdir):
         in_path=GEO_FILEPATH,
         field_mapping={"attribute_value": "value"},
         pattern="test_attr_*.parquet",
+        location_id_prefix="usgs",
     )
 
     assert True

--- a/tests/test_import_location_crosswalks.py
+++ b/tests/test_import_location_crosswalks.py
@@ -34,8 +34,22 @@ def test_validate_and_insert_crosswalks(tmpdir):
     )
 
     ev.location_crosswalks.load_csv(
-        in_path=CROSSWALK_FILEPATH
+        in_path=CROSSWALK_FILEPATH,
+        primary_location_id_prefix="usgs",
+        secondary_location_id_prefix="nwm30",
     )
+
+    df = ev.location_crosswalks.to_pandas()
+    assert df["primary_location_id"].tolist() == [
+        "usgs-A",
+        "usgs-B",
+        "usgs-C",
+    ]
+    assert df["secondary_location_id"].tolist() == [
+        "nwm30-1",
+        "nwm30-2",
+        "nwm30-3",
+    ]
 
     assert True
 

--- a/tests/test_import_location_crosswalks.py
+++ b/tests/test_import_location_crosswalks.py
@@ -30,7 +30,8 @@ def test_validate_and_insert_crosswalks(tmpdir):
     ev.clone_template()
 
     ev.locations.load_spatial(
-        in_path=GEOJSON_GAGES_FILEPATH
+        in_path=GEOJSON_GAGES_FILEPATH,
+        location_id_prefix="usgs"
     )
 
     ev.location_crosswalks.load_csv(

--- a/tests/test_import_locations.py
+++ b/tests/test_import_locations.py
@@ -36,21 +36,24 @@ def test_validate_and_insert_locations(tmpdir):
     ev.locations.load_spatial(
         in_path="tests/data/two_locations/two_locations.parquet",
     )
-    # Now say I want to update existing locations
+    # Now update existing 'test' locations with new names
+    # and add a few more (upsert).
     ev.locations.load_spatial(
-        in_path=GEOJSON_GAGES_FILEPATH,
-        location_id_prefix="updated",
+        in_path=Path(TEST_STUDY_DATA_DIR, "geo", "extended_v03_gages.geojson"),
+        location_id_prefix="test",
         write_mode="upsert",
-        update_columns=["id"]
     )
     assert ev.locations.to_pandas()["id"].tolist() == [
         "usgs-14316700",
         "usgs-14138800",
-        "updated-A",
-        "updated-B",
-        "updated-C"
+        "test-A",
+        "test-B",
+        "test-C",
+        "test-D",
+        "test-E",
+        "test-F"
     ]
-    assert ev.locations.to_sdf().count() == 5
+    assert ev.locations.to_sdf().count() == 8
 
 
 def test_validate_and_insert_locations_adding_prefix(tmpdir):

--- a/tests/test_import_locations.py
+++ b/tests/test_import_locations.py
@@ -43,15 +43,15 @@ def test_validate_and_insert_locations(tmpdir):
         location_id_prefix="test",
         write_mode="upsert",
     )
-    assert ev.locations.to_pandas()["id"].tolist() == [
-        "usgs-14316700",
-        "usgs-14138800",
+    assert sorted(ev.locations.to_pandas()["id"].tolist()) == [
         "test-A",
         "test-B",
         "test-C",
         "test-D",
         "test-E",
-        "test-F"
+        "test-F",
+        "usgs-14138800",
+        "usgs-14316700"
     ]
     assert ev.locations.to_sdf().count() == 8
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -4,7 +4,6 @@ This module tests the filter functions on primary_timeseries. It
 should apply to all tables.
 """
 import tempfile
-import pytest
 
 from setup_v0_3_study import setup_v0_3_study
 
@@ -18,23 +17,22 @@ def test_sql_query(tmpdir):
         JOIN configurations c ON pt.configuration_name = c.name
         LIMIT 10;
     """)
-    sdf_cols = sdf.columns
+    sdf_cols = sorted(sdf.columns)
     expected_cols = [
-        'value_time',
-        'value',
-        'unit_name',
-        'location_id',
         'configuration_name',
-        'variable_name',
-        'reference_time',
-        'name',
+        'description',
+        'location_id',
         'long_name',
         'name',
+        'name',
+        'reference_time',
         'type',
-        'description'
+        'unit_name',
+        'value',
+        'value_time',
+        'variable_name'
     ]
     assert sdf_cols == expected_cols
-
 
 
 if __name__ == "__main__":

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -20,13 +20,13 @@ def test_sql_query(tmpdir):
     """)
     sdf_cols = sdf.columns
     expected_cols = [
-        'reference_time',
         'value_time',
         'value',
         'unit_name',
         'location_id',
         'configuration_name',
         'variable_name',
+        'reference_time',
         'name',
         'long_name',
         'name',


### PR DESCRIPTION
- Adds append and upsert functionality without duplicates to loading methods on tables:
    - locations
    - location crosswalk
    - location attributes
    - primary and secondary timeseries
- Upsert argument also added to fetching methods (append is default). 
- Fetching cache is cleared before each call.
- Append and upsert ensure no duplicates are added using a join, with the join fields defined on each table class (`self.unique_column_set`)
- Append only writes new data in append mode.
- Upsert 
    - Can only update columns not included in `unique_column_set`
    - Appends new data a overwrites affected partitions only (writes in overwrite mode)
- Also adds ability to add or update the location id prefix during loading in above tables 
- Adds `reference_time` as a default partition for timeseries
    - If `reference_time` column is null, it's removed as a partition before writing
- Adds script to re-write timeseries tables partitioned on `reference_time`
- Adds function to drop potential duplicates before writing tables (`_drop_duplicates()`) 