### PR TITLE
Updated timeseries plotting to resolve out-of-order line plotting bug.

### DIFF
--- a/src/teehr/visualization/dataframe_accessor.py
+++ b/src/teehr/visualization/dataframe_accessor.py
@@ -437,6 +437,8 @@ class TEEHRDataFrameAccessor:
                         (df['location_id'] == combo[1]) &
                         (df['reference_time'].isnull())
                         ]
+                    temp = temp.sort_values(by='value_time')
+                    temp = temp.reset_index(drop=True)
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
                         p.line(
@@ -456,6 +458,8 @@ class TEEHRDataFrameAccessor:
                         (df['location_id'] == combo[1]) &
                         (df['reference_time'] == combo[2])
                         ]
+                    temp = temp.sort_values(by='value_time')
+                    temp = temp.reset_index(drop=True)
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
                         label = f"{combo[0]} - {combo[1]} - {combo[2]}"
@@ -486,6 +490,8 @@ class TEEHRDataFrameAccessor:
                         (df['reference_time'].isnull()) &
                         (df['member'].isnull())
                         ]
+                    temp = temp.sort_values(by='value_time')
+                    temp = temp.reset_index(drop=True)
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
                         p.line(
@@ -510,6 +516,8 @@ class TEEHRDataFrameAccessor:
                         (df['reference_time'].isnull()) &
                         (df['member'] == combo[3])
                         ]
+                    temp = temp.sort_values(by='value_time')
+                    temp = temp.reset_index(drop=True)
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
                         label = f"{combo[0]} - {combo[1]} - {combo[3]}"
@@ -535,6 +543,8 @@ class TEEHRDataFrameAccessor:
                         (df['reference_time'] == combo[2]) &
                         (df['member'].isnull())
                         ]
+                    temp = temp.sort_values(by='value_time')
+                    temp = temp.reset_index(drop=True)
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
                         label = f"{combo[0]} - {combo[1]} - {combo[2]}"
@@ -556,6 +566,8 @@ class TEEHRDataFrameAccessor:
                         (df['reference_time'] == combo[2]) &
                         (df['member'] == combo[3])
                         ]
+                    temp = temp.sort_values(by='value_time')
+                    temp = temp.reset_index(drop=True)
                     if not temp.empty:
                         logger.info(f"Plotting data for combination: {combo}")
                         label = f"{combo[0]} - {combo[1]} - {combo[2]} - \


### PR DESCRIPTION
- Updated the accessor to resolve the bug where the timeseries_plot method was plotting the datapoints out of order.
- All tests/examples pass.
- Rebuilt docs locally to compare with an example where the error was occurring (https://rtiinternational.github.io/teehr/user_guide/notebooks/04_setup_simple_example.html) -- update resolved the error.