### PR TITLE
441 handle nan values when fetching andor loading

### DIFF
--- a/docs/sphinx/development/index.rst
+++ b/docs/sphinx/development/index.rst
@@ -16,29 +16,39 @@ Install the prerequisites:
 
 
 1. Clone the TEEHR repository from GitHub:
-```bash
-git clone https://github.com/RTIInternational/teehr.git
-```
+
+.. code-block:: bash
+
+   git clone https://github.com/RTIInternational/teehr.git
+
 
 2. Navigate to the TEEHR directory:
-```bash
-cd teehr
-```
+
+.. code-block:: bash
+
+   cd teehr
+
 
 3. Create a new virtual environment using poetry:
-```bash
-poetry install
-```
+
+.. code-block:: bash
+
+   poetry install
+
 
 4. Activate the virtual environment:
-```bash
-poetry shell
-```
+
+.. code-block:: bash
+
+   poetry shell
+
 
 5. Install the required JAR files for Spark:
-```bash
-python download_spark_jars.py
-```
+
+.. code-block:: bash
+
+   python download_spark_jars.py
+
 
 Contributing Guidelines
 -----------------------

--- a/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
+++ b/docs/sphinx/user_guide/notebooks/10_fetching_nwm_streamflow.ipynb
@@ -243,7 +243,7 @@
     "    output_type=\"channel_rt_1\",\n",
     "    variable_name=\"streamflow\",\n",
     "    start_date=datetime(2024, 9, 26),\n",
-    "    ingest_days=1,\n",
+    "    end_date=datetime(2024, 9, 26),\n",
     "    nwm_version=\"nwm30\",\n",
     ")\n",
     "```"

--- a/docs/sphinx/user_guide/notebooks/11_fetching_nwm_gridded_data.ipynb
+++ b/docs/sphinx/user_guide/notebooks/11_fetching_nwm_gridded_data.ipynb
@@ -1,497 +1,497 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Fetching and Summarizing NWM Gridded Data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Overview\n",
-    "In this guide we'll demonstrate fetching National Water Model (NWM) operational and retrospective gridded data from cloud storage. This example makes use of a pre-generated Evaluation dataset stored in TEEHR's examples data module.\n",
-    "\n",
-    "**Note**: For demonstration purposes several cells below are shown in markdown form. If you want to download this notebook and run them yourself, you will need to convert them to code cells.\n",
-    "\n",
-    "For a refresher on loading location and location crosswalk data into a new Evaluation refer back to the [Loading Local Data](https://rtiinternational.github.io/teehr/user_guide/notebooks/02_loading_local_data.html) and [Setting-up a Simple Example](https://rtiinternational.github.io/teehr/user_guide/notebooks/04_setup_simple_example.html) user guide pages."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Set up the example Evaluation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "from pathlib import Path\n",
-    "import shutil\n",
-    "import hvplot.pandas  # noqa\n",
-    "import pandas as pd\n",
-    "\n",
-    "from teehr.examples.setup_nwm_grid_example import setup_nwm_example\n",
-    "import teehr\n",
-    "from teehr.evaluation.utils import print_tree\n",
-    "\n",
-    "# Tell Bokeh to output plots in the notebook\n",
-    "from bokeh.io import output_notebook\n",
-    "output_notebook()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We'll start with the Evaluation from the previous User Guide, which contains observed (USGS) and simulation (NWM) streamflow for a gage at Radford, VA during hurricane Helene."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Define the directory where the Evaluation will be created.\n",
-    "test_eval_dir = Path(Path().home(), \"temp\", \"11_fetch_gridded_nwm_data\")\n",
-    "\n",
-    "# Setup the example evaluation using data from the TEEHR repository.\n",
-    "shutil.rmtree(test_eval_dir, ignore_errors=True)\n",
-    "setup_nwm_example(tmpdir=test_eval_dir)\n",
-    "\n",
-    "# Initialize the evaluation.\n",
-    "ev = teehr.Evaluation(dir_path=test_eval_dir)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ev.locations.to_geopandas()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can add polygons to summarize rainfall to, to see the impact of the forcing data on the NWM streamflow prediction"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "location_data_path = Path(test_eval_dir, \"three_huc10s_radford.parquet\")\n",
-    "\n",
-    "ev.locations.load_spatial(\n",
-    "    location_data_path,\n",
-    "    field_mapping={\n",
-    "        \"huc10\": \"id\"\n",
-    "    },\n",
-    "    location_id_prefix=\"wbd\",\n",
-    "    write_mode=\"append\"  # this is the default\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we have the USGS gage point, and three WBD HUC10 polygons in the locations table."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdf = ev.locations.to_geopandas()\n",
-    "gdf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdf[gdf.id != \"usgs-03171000\"].hvplot(geo=True, tiles=\"OSM\", alpha=0.5) * \\\n",
-    "    gdf[gdf.id == \"usgs-03171000\"].hvplot(geo=True, color=\"black\", size=50)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we'll fetch NWM gridded analysis and assimilation rainfall data and calculate mean areal precipitation (MAP) for each of the HUC10 watersheds. We'll consider this \"observed\" primary timeseries. \n",
-    "\n",
-    "The location ID prefix is used to filter the locations table for WBD polygons during fetching. The calculated MAP timeseries will be appended (the default) to the `primary_timeseries` table along with the streamflow data (the primary timeseries table will contain both streamflow and rainfall)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "# To run this cell locally first convert it to a python cell\n",
-    "ev.fetch.nwm_operational_grids(\n",
-    "    nwm_configuration=\"forcing_analysis_assim\",\n",
-    "    output_type=\"forcing\",\n",
-    "    variable_name=\"RAINRATE\",\n",
-    "    start_date=datetime(2024, 9, 26),\n",
-    "    ingest_days=1,\n",
-    "    nwm_version=\"nwm30\",\n",
-    "    prioritize_analysis_valid_time=True,\n",
-    "    t_minus_hours=[0],\n",
-    "    calculate_zonal_weights=True,\n",
-    "    location_id_prefix=\"wbd\",\n",
-    "    timeseries_type=\"primary\"  # To be considered \"observations\". This is the default.\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "primary_df = ev.primary_timeseries.to_pandas()\n",
-    "primary_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's take a look at the `cache` directory. After fetching the NWM analysis forcing, we have a directory for the weights file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print_tree(Path(ev.cache_dir, \"fetching\", \"weights\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The weights file contains the fractional coverage for each pixel (row/col pair) that intersects with each polygon location (WBD HUC10 watershed)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cached_weights_filepath = Path(\n",
-    "        ev.cache_dir,\n",
-    "        \"fetching\",\n",
-    "        \"weights\",\n",
-    "        \"nwm30_forcing_analysis_assim\",\n",
-    "        \"nwm30_forcing_analysis_assim_pixel_weights.parquet\"\n",
-    ")\n",
-    "pd.read_parquet(cached_weights_filepath)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can fetch the NWM forecast rainfall and calculate MAP, to compare it to the \"observed\" rainfall. First we need to create and import the `location_crosswalks` table, which maps the secondary locations (\"model\") to the primary (\"observations\")."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ev.locations.to_pandas()[\"id\"].unique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "xwalk_df = pd.DataFrame(\n",
-    "    {\n",
-    "        \"primary_location_id\": [\n",
-    "            \"wbd-0505000115\",\n",
-    "            \"wbd-0505000117\",\n",
-    "            \"wbd-0505000118\"\n",
-    "        ],\n",
-    "        \"secondary_location_id\": [\n",
-    "            \"forecast-0505000115\",\n",
-    "            \"forecast-0505000117\",\n",
-    "            \"forecast-0505000118\"\n",
-    "        ]\n",
-    "    }\n",
-    ")\n",
-    "temp_xwalk_path = Path(ev.cache_dir, \"forcing_xwalk.parquet\")\n",
-    "xwalk_df.to_parquet(temp_xwalk_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can load it into the Evaluation, appending to the existing table."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ev.location_crosswalks.load_parquet(temp_xwalk_path)\n",
-    "ev.location_crosswalks.to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can fetch the NWM forecast rainfall, which we'll consider the \"secondary\" timeseries. Let's grab a single short range rainfall forecast"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```python\n",
-    "# To run this cell locally first convert it to a python cell\n",
-    "ev.fetch.nwm_operational_grids(\n",
-    "    nwm_configuration=\"forcing_short_range\",\n",
-    "    output_type=\"forcing\",\n",
-    "    variable_name=\"RAINRATE\",\n",
-    "    start_date=datetime(2024, 9, 26),\n",
-    "    ingest_days=1,\n",
-    "    nwm_version=\"nwm30\",\n",
-    "    location_id_prefix=\"forecast\",\n",
-    "    calculate_zonal_weights=False,  # re-use the weights file in the cache\n",
-    "    zonal_weights_filepath=cached_weights_filepath,\n",
-    "    starting_z_hour=1,\n",
-    "    ending_z_hour=1,\n",
-    "    timeseries_type=\"secondary\"  # now considered forecast\n",
-    ")\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And our `secondary_timeseries` table consists of NWM medium range streamflow forecasts (member 1), plus NWM short range rainfall forecast summarized to the three WBD HUC10 watersheds as mean areal precipitation (MAP)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "secondary_df = ev.secondary_timeseries.to_pandas()\n",
-    "secondary_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And our `primary_timeseries` table consists of USGS streamflow data at the Radford gage, plus NWM analysis rainfall summarized to the three WBD HUC10 watersheds as mean areal precipitation (MAP)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "primary_df = ev.primary_timeseries.to_pandas()\n",
-    "primary_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can create the `joined_timeseries` table allowing for efficient metric calculation and further exploration."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ev.joined_timeseries.create()\n",
-    "\n",
-    "joined_df = ev.joined_timeseries.to_pandas()\n",
-    "joined_df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "joined_df.configuration_name.unique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We'll use this helper function for plotting timeseries.\n",
-    "def plot_timeseries(\n",
-    "    configuration_name: str,\n",
-    "    secondary_by: list[str],\n",
-    "    title: str\n",
-    "):\n",
-    "    sim_plot = joined_df[joined_df[\"configuration_name\"] == configuration_name].\\\n",
-    "        hvplot(\n",
-    "            x=\"value_time\",\n",
-    "            y=\"secondary_value\",\n",
-    "            by=secondary_by,\n",
-    "            legend=False,\n",
-    "            )\n",
-    "    obs_plot = joined_df[joined_df[\"configuration_name\"] == configuration_name].\\\n",
-    "        hvplot(\n",
-    "            x=\"value_time\",\n",
-    "            y=\"primary_value\",\n",
-    "            by=[\"primary_location_id\", \"configuration_name\"],\n",
-    "            legend=False,\n",
-    "            color=\"black\"\n",
-    "            )\n",
-    "    return (sim_plot * obs_plot).options(\n",
-    "                width=700,\n",
-    "                height=400,\n",
-    "                show_grid=True,\n",
-    "                title=title\n",
-    "            )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can plot the primary (USGS) vs. secondary (NWM) streamflow and notice that this particular NWM forecast underestimated the flow."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_timeseries(\n",
-    "    configuration_name=\"nwm30_medium_range\",\n",
-    "    secondary_by=[\"reference_time\"],\n",
-    "    title=\"Observed streamflow (black) and forecast streamflow at the Radford gage\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In plotting the primary vs. secondary rainfall (MAP) in each watershed, we can see the this NWM forecast underestimated the observed rainfall. This is likely one reason why the NWM streamflow forecasts also underestimated the flow."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_timeseries(\n",
-    "    configuration_name=\"nwm30_forcing_short_range\",\n",
-    "    secondary_by=[\"primary_location_id\"],\n",
-    "    title=\"Observed MAP (black) and forecast MAP at the three HUC10s\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can also calculate performance metrics for the streamflow and rainfall for this event."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bias = teehr.DeterministicMetrics.RelativeBias()\n",
-    "kge = teehr.DeterministicMetrics.KlingGuptaEfficiency()\n",
-    "\n",
-    "ev.metrics.query(\n",
-    "    include_metrics=[bias, kge],\n",
-    "    group_by=[\"primary_location_id\", \"configuration_name\"],\n",
-    "    order_by=[\"primary_location_id\", \"configuration_name\"],\n",
-    ").to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ev.spark.stop()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Fetching and Summarizing NWM Gridded Data"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Overview\n",
+                "In this guide we'll demonstrate fetching National Water Model (NWM) operational and retrospective gridded data from cloud storage. This example makes use of a pre-generated Evaluation dataset stored in TEEHR's examples data module.\n",
+                "\n",
+                "**Note**: For demonstration purposes several cells below are shown in markdown form. If you want to download this notebook and run them yourself, you will need to convert them to code cells.\n",
+                "\n",
+                "For a refresher on loading location and location crosswalk data into a new Evaluation refer back to the [Loading Local Data](https://rtiinternational.github.io/teehr/user_guide/notebooks/02_loading_local_data.html) and [Setting-up a Simple Example](https://rtiinternational.github.io/teehr/user_guide/notebooks/04_setup_simple_example.html) user guide pages."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Set up the example Evaluation"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from datetime import datetime\n",
+                "from pathlib import Path\n",
+                "import shutil\n",
+                "import hvplot.pandas  # noqa\n",
+                "import pandas as pd\n",
+                "\n",
+                "from teehr.examples.setup_nwm_grid_example import setup_nwm_example\n",
+                "import teehr\n",
+                "from teehr.evaluation.utils import print_tree\n",
+                "\n",
+                "# Tell Bokeh to output plots in the notebook\n",
+                "from bokeh.io import output_notebook\n",
+                "output_notebook()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "We'll start with the Evaluation from the previous User Guide, which contains observed (USGS) and simulation (NWM) streamflow for a gage at Radford, VA during hurricane Helene."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "tags": [
+                    "hide-output"
+                ]
+            },
+            "outputs": [],
+            "source": [
+                "# Define the directory where the Evaluation will be created.\n",
+                "test_eval_dir = Path(Path().home(), \"temp\", \"11_fetch_gridded_nwm_data\")\n",
+                "\n",
+                "# Setup the example evaluation using data from the TEEHR repository.\n",
+                "shutil.rmtree(test_eval_dir, ignore_errors=True)\n",
+                "setup_nwm_example(tmpdir=test_eval_dir)\n",
+                "\n",
+                "# Initialize the evaluation.\n",
+                "ev = teehr.Evaluation(dir_path=test_eval_dir)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ev.locations.to_geopandas()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "We can add polygons to summarize rainfall to, to see the impact of the forcing data on the NWM streamflow prediction"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "location_data_path = Path(test_eval_dir, \"three_huc10s_radford.parquet\")\n",
+                "\n",
+                "ev.locations.load_spatial(\n",
+                "    location_data_path,\n",
+                "    field_mapping={\n",
+                "        \"huc10\": \"id\"\n",
+                "    },\n",
+                "    location_id_prefix=\"wbd\",\n",
+                "    write_mode=\"append\"  # this is the default\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we have the USGS gage point, and three WBD HUC10 polygons in the locations table."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "gdf = ev.locations.to_geopandas()\n",
+                "gdf"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "gdf[gdf.id != \"usgs-03171000\"].hvplot(geo=True, tiles=\"OSM\", alpha=0.5) * \\\n",
+                "    gdf[gdf.id == \"usgs-03171000\"].hvplot(geo=True, color=\"black\", size=50)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we'll fetch NWM gridded analysis and assimilation rainfall data and calculate mean areal precipitation (MAP) for each of the HUC10 watersheds. We'll consider this \"observed\" primary timeseries. \n",
+                "\n",
+                "The location ID prefix is used to filter the locations table for WBD polygons during fetching. The calculated MAP timeseries will be appended (the default) to the `primary_timeseries` table along with the streamflow data (the primary timeseries table will contain both streamflow and rainfall)."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "```python\n",
+                "# To run this cell locally first convert it to a python cell\n",
+                "ev.fetch.nwm_operational_grids(\n",
+                "    nwm_configuration=\"forcing_analysis_assim\",\n",
+                "    output_type=\"forcing\",\n",
+                "    variable_name=\"RAINRATE\",\n",
+                "    start_date=datetime(2024, 9, 26),\n",
+                "    end_date=datetime(2024, 9, 26),\n",
+                "    nwm_version=\"nwm30\",\n",
+                "    prioritize_analysis_value_time=True,\n",
+                "    t_minus_hours=[0],\n",
+                "    calculate_zonal_weights=True,\n",
+                "    location_id_prefix=\"wbd\",\n",
+                "    timeseries_type=\"primary\"  # To be considered \"observations\". This is the default.\n",
+                ")\n",
+                "```"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "primary_df = ev.primary_timeseries.to_pandas()\n",
+                "primary_df.head()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Let's take a look at the `cache` directory. After fetching the NWM analysis forcing, we have a directory for the weights file."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "print_tree(Path(ev.cache_dir, \"fetching\", \"weights\"))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "The weights file contains the fractional coverage for each pixel (row/col pair) that intersects with each polygon location (WBD HUC10 watershed)."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "cached_weights_filepath = Path(\n",
+                "        ev.cache_dir,\n",
+                "        \"fetching\",\n",
+                "        \"weights\",\n",
+                "        \"nwm30_forcing_analysis_assim\",\n",
+                "        \"nwm30_forcing_analysis_assim_pixel_weights.parquet\"\n",
+                ")\n",
+                "pd.read_parquet(cached_weights_filepath)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we can fetch the NWM forecast rainfall and calculate MAP, to compare it to the \"observed\" rainfall. First we need to create and import the `location_crosswalks` table, which maps the secondary locations (\"model\") to the primary (\"observations\")."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ev.locations.to_pandas()[\"id\"].unique()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "xwalk_df = pd.DataFrame(\n",
+                "    {\n",
+                "        \"primary_location_id\": [\n",
+                "            \"wbd-0505000115\",\n",
+                "            \"wbd-0505000117\",\n",
+                "            \"wbd-0505000118\"\n",
+                "        ],\n",
+                "        \"secondary_location_id\": [\n",
+                "            \"forecast-0505000115\",\n",
+                "            \"forecast-0505000117\",\n",
+                "            \"forecast-0505000118\"\n",
+                "        ]\n",
+                "    }\n",
+                ")\n",
+                "temp_xwalk_path = Path(ev.cache_dir, \"forcing_xwalk.parquet\")\n",
+                "xwalk_df.to_parquet(temp_xwalk_path)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we can load it into the Evaluation, appending to the existing table."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ev.location_crosswalks.load_parquet(temp_xwalk_path)\n",
+                "ev.location_crosswalks.to_pandas()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we can fetch the NWM forecast rainfall, which we'll consider the \"secondary\" timeseries. Let's grab a single short range rainfall forecast"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "```python\n",
+                "# To run this cell locally first convert it to a python cell\n",
+                "ev.fetch.nwm_operational_grids(\n",
+                "    nwm_configuration=\"forcing_short_range\",\n",
+                "    output_type=\"forcing\",\n",
+                "    variable_name=\"RAINRATE\",\n",
+                "    start_date=datetime(2024, 9, 26),\n",
+                "    end_date=datetime(2024, 9, 26),\n",
+                "    nwm_version=\"nwm30\",\n",
+                "    location_id_prefix=\"forecast\",\n",
+                "    calculate_zonal_weights=False,  # re-use the weights file in the cache\n",
+                "    zonal_weights_filepath=cached_weights_filepath,\n",
+                "    starting_z_hour=1,\n",
+                "    ending_z_hour=1,\n",
+                "    timeseries_type=\"secondary\"  # now considered forecast\n",
+                ")\n",
+                "```"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "And our `secondary_timeseries` table consists of NWM medium range streamflow forecasts (member 1), plus NWM short range rainfall forecast summarized to the three WBD HUC10 watersheds as mean areal precipitation (MAP)."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "secondary_df = ev.secondary_timeseries.to_pandas()\n",
+                "secondary_df.head()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "And our `primary_timeseries` table consists of USGS streamflow data at the Radford gage, plus NWM analysis rainfall summarized to the three WBD HUC10 watersheds as mean areal precipitation (MAP)."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "primary_df = ev.primary_timeseries.to_pandas()\n",
+                "primary_df.head()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we can create the `joined_timeseries` table allowing for efficient metric calculation and further exploration."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ev.joined_timeseries.create()\n",
+                "\n",
+                "joined_df = ev.joined_timeseries.to_pandas()\n",
+                "joined_df.head()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "joined_df.configuration_name.unique()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# We'll use this helper function for plotting timeseries.\n",
+                "def plot_timeseries(\n",
+                "    configuration_name: str,\n",
+                "    secondary_by: list[str],\n",
+                "    title: str\n",
+                "):\n",
+                "    sim_plot = joined_df[joined_df[\"configuration_name\"] == configuration_name].\\\n",
+                "        hvplot(\n",
+                "            x=\"value_time\",\n",
+                "            y=\"secondary_value\",\n",
+                "            by=secondary_by,\n",
+                "            legend=False,\n",
+                "            )\n",
+                "    obs_plot = joined_df[joined_df[\"configuration_name\"] == configuration_name].\\\n",
+                "        hvplot(\n",
+                "            x=\"value_time\",\n",
+                "            y=\"primary_value\",\n",
+                "            by=[\"primary_location_id\", \"configuration_name\"],\n",
+                "            legend=False,\n",
+                "            color=\"black\"\n",
+                "            )\n",
+                "    return (sim_plot * obs_plot).options(\n",
+                "                width=700,\n",
+                "                height=400,\n",
+                "                show_grid=True,\n",
+                "                title=title\n",
+                "            )"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "We can plot the primary (USGS) vs. secondary (NWM) streamflow and notice that this particular NWM forecast underestimated the flow."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "plot_timeseries(\n",
+                "    configuration_name=\"nwm30_medium_range\",\n",
+                "    secondary_by=[\"reference_time\"],\n",
+                "    title=\"Observed streamflow (black) and forecast streamflow at the Radford gage\"\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "In plotting the primary vs. secondary rainfall (MAP) in each watershed, we can see the this NWM forecast underestimated the observed rainfall. This is likely one reason why the NWM streamflow forecasts also underestimated the flow."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "plot_timeseries(\n",
+                "    configuration_name=\"nwm30_forcing_short_range\",\n",
+                "    secondary_by=[\"primary_location_id\"],\n",
+                "    title=\"Observed MAP (black) and forecast MAP at the three HUC10s\"\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Now we can also calculate performance metrics for the streamflow and rainfall for this event."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "bias = teehr.DeterministicMetrics.RelativeBias()\n",
+                "kge = teehr.DeterministicMetrics.KlingGuptaEfficiency()\n",
+                "\n",
+                "ev.metrics.query(\n",
+                "    include_metrics=[bias, kge],\n",
+                "    group_by=[\"primary_location_id\", \"configuration_name\"],\n",
+                "    order_by=[\"primary_location_id\", \"configuration_name\"],\n",
+                ").to_pandas()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ev.spark.stop()"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": ".venv",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.12"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,7 +865,7 @@ version = "3.1.0"
 description = "Pickler class to extend the standard pickle.Pickler functionality"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "cloudpickle-3.1.0-py3-none-any.whl", hash = "sha256:fe11acda67f61aaaec473e3afe030feb131d78a43461b718185363384f1ba12e"},
     {file = "cloudpickle-3.1.0.tar.gz", hash = "sha256:81a929b6e3c7335c863c771d673d105f02efdb89dfaba0c90495d1c64796601b"},
@@ -1014,19 +1014,20 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "dask"
-version = "2025.2.0"
+version = "2025.5.1"
 description = "Parallel PyData with Task Scheduling"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
-    {file = "dask-2025.2.0-py3-none-any.whl", hash = "sha256:f0fdeef6ceb0a06569d456c9e704f220f7f54e80f3a6ea42ab98cea6bc642b6e"},
-    {file = "dask-2025.2.0.tar.gz", hash = "sha256:89c87125d04d28141eaccc4794164ce9098163fd22d8ad943db48f8d4c815460"},
+    {file = "dask-2025.5.1-py3-none-any.whl", hash = "sha256:3b85fdaa5f6f989dde49da6008415b1ae996985ebdfb1e40de2c997d9010371d"},
+    {file = "dask-2025.5.1.tar.gz", hash = "sha256:979d9536549de0e463f4cab8a8c66c3a2ef55791cd740d07d9bf58fab1d1076a"},
 ]
 
 [package.dependencies]
 click = ">=8.1"
 cloudpickle = ">=3.0.0"
+distributed = {version = "2025.5.1", optional = true, markers = "extra == \"distributed\""}
 fsspec = ">=2021.09.0"
 importlib_metadata = {version = ">=4.13.0", markers = "python_version < \"3.12\""}
 numpy = {version = ">=1.24", optional = true, markers = "extra == \"array\""}
@@ -1042,7 +1043,7 @@ array = ["numpy (>=1.24)"]
 complete = ["dask[array,dataframe,diagnostics,distributed]", "lz4 (>=4.3.2)", "pyarrow (>=14.0.1)"]
 dataframe = ["dask[array]", "pandas (>=2.0)", "pyarrow (>=14.0.1)"]
 diagnostics = ["bokeh (>=3.1.0)", "jinja2 (>=2.10.3)"]
-distributed = ["distributed (==2025.2.0)"]
+distributed = ["distributed (==2025.5.1)"]
 test = ["pandas[test]", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist"]
 
 [[package]]
@@ -1125,6 +1126,35 @@ files = [
     {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
     {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
 ]
+
+[[package]]
+name = "distributed"
+version = "2025.5.1"
+description = "Distributed scheduler for Dask"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "distributed-2025.5.1-py3-none-any.whl", hash = "sha256:74782b965ddb24ce59c6441fa777e944b5962d82325cc41f228537b59bb7fbbe"},
+    {file = "distributed-2025.5.1.tar.gz", hash = "sha256:cf1d62a2c17a0a9fc1544bd10bb7afd39f22f24aaa9e3df3209c44d2cfb16703"},
+]
+
+[package.dependencies]
+click = ">=8.0"
+cloudpickle = ">=3.0.0"
+dask = "2025.5.1"
+jinja2 = ">=2.10.3"
+locket = ">=1.0.0"
+msgpack = ">=1.0.2"
+packaging = ">=20.0"
+psutil = ">=5.8.0"
+pyyaml = ">=5.4.1"
+sortedcontainers = ">=2.0.5"
+tblib = ">=1.6.0"
+toolz = ">=0.11.2"
+tornado = ">=6.2.0"
+urllib3 = ">=1.26.5"
+zict = ">=3.0.0"
 
 [[package]]
 name = "docutils"
@@ -1477,7 +1507,7 @@ version = "2024.12.0"
 description = "File-system specification"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "fsspec-2024.12.0-py3-none-any.whl", hash = "sha256:b520aed47ad9804237ff878b504267a3b0b441e97508bd6d2d8774e3db85cee2"},
     {file = "fsspec-2024.12.0.tar.gz", hash = "sha256:670700c977ed2fb51e0d9f9253177ed20cbde4a3e5c0283cc5385b5870c8533f"},
@@ -2595,7 +2625,7 @@ version = "1.0.0"
 description = "File-based locks for Python on Linux and Windows"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
     {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
@@ -2983,6 +3013,75 @@ groups = ["main", "dev"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.1"
+description = "MessagePack serializer"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "msgpack-1.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:353b6fc0c36fde68b661a12949d7d49f8f51ff5fa019c1e47c87c4ff34b080ed"},
+    {file = "msgpack-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:79c408fcf76a958491b4e3b103d1c417044544b68e96d06432a189b43d1215c8"},
+    {file = "msgpack-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78426096939c2c7482bf31ef15ca219a9e24460289c00dd0b94411040bb73ad2"},
+    {file = "msgpack-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b17ba27727a36cb73aabacaa44b13090feb88a01d012c0f4be70c00f75048b4"},
+    {file = "msgpack-1.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a17ac1ea6ec3c7687d70201cfda3b1e8061466f28f686c24f627cae4ea8efd0"},
+    {file = "msgpack-1.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:88d1e966c9235c1d4e2afac21ca83933ba59537e2e2727a999bf3f515ca2af26"},
+    {file = "msgpack-1.1.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:f6d58656842e1b2ddbe07f43f56b10a60f2ba5826164910968f5933e5178af75"},
+    {file = "msgpack-1.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:96decdfc4adcbc087f5ea7ebdcfd3dee9a13358cae6e81d54be962efc38f6338"},
+    {file = "msgpack-1.1.1-cp310-cp310-win32.whl", hash = "sha256:6640fd979ca9a212e4bcdf6eb74051ade2c690b862b679bfcb60ae46e6dc4bfd"},
+    {file = "msgpack-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:8b65b53204fe1bd037c40c4148d00ef918eb2108d24c9aaa20bc31f9810ce0a8"},
+    {file = "msgpack-1.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:71ef05c1726884e44f8b1d1773604ab5d4d17729d8491403a705e649116c9558"},
+    {file = "msgpack-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:36043272c6aede309d29d56851f8841ba907a1a3d04435e43e8a19928e243c1d"},
+    {file = "msgpack-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a32747b1b39c3ac27d0670122b57e6e57f28eefb725e0b625618d1b59bf9d1e0"},
+    {file = "msgpack-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a8b10fdb84a43e50d38057b06901ec9da52baac6983d3f709d8507f3889d43f"},
+    {file = "msgpack-1.1.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ba0c325c3f485dc54ec298d8b024e134acf07c10d494ffa24373bea729acf704"},
+    {file = "msgpack-1.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:88daaf7d146e48ec71212ce21109b66e06a98e5e44dca47d853cbfe171d6c8d2"},
+    {file = "msgpack-1.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d8b55ea20dc59b181d3f47103f113e6f28a5e1c89fd5b67b9140edb442ab67f2"},
+    {file = "msgpack-1.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4a28e8072ae9779f20427af07f53bbb8b4aa81151054e882aee333b158da8752"},
+    {file = "msgpack-1.1.1-cp311-cp311-win32.whl", hash = "sha256:7da8831f9a0fdb526621ba09a281fadc58ea12701bc709e7b8cbc362feabc295"},
+    {file = "msgpack-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:5fd1b58e1431008a57247d6e7cc4faa41c3607e8e7d4aaf81f7c29ea013cb458"},
+    {file = "msgpack-1.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ae497b11f4c21558d95de9f64fff7053544f4d1a17731c866143ed6bb4591238"},
+    {file = "msgpack-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33be9ab121df9b6b461ff91baac6f2731f83d9b27ed948c5b9d1978ae28bf157"},
+    {file = "msgpack-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f64ae8fe7ffba251fecb8408540c34ee9df1c26674c50c4544d72dbf792e5ce"},
+    {file = "msgpack-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a494554874691720ba5891c9b0b39474ba43ffb1aaf32a5dac874effb1619e1a"},
+    {file = "msgpack-1.1.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb643284ab0ed26f6957d969fe0dd8bb17beb567beb8998140b5e38a90974f6c"},
+    {file = "msgpack-1.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d275a9e3c81b1093c060c3837e580c37f47c51eca031f7b5fb76f7b8470f5f9b"},
+    {file = "msgpack-1.1.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4fd6b577e4541676e0cc9ddc1709d25014d3ad9a66caa19962c4f5de30fc09ef"},
+    {file = "msgpack-1.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb29aaa613c0a1c40d1af111abf025f1732cab333f96f285d6a93b934738a68a"},
+    {file = "msgpack-1.1.1-cp312-cp312-win32.whl", hash = "sha256:870b9a626280c86cff9c576ec0d9cbcc54a1e5ebda9cd26dab12baf41fee218c"},
+    {file = "msgpack-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:5692095123007180dca3e788bb4c399cc26626da51629a31d40207cb262e67f4"},
+    {file = "msgpack-1.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3765afa6bd4832fc11c3749be4ba4b69a0e8d7b728f78e68120a157a4c5d41f0"},
+    {file = "msgpack-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8ddb2bcfd1a8b9e431c8d6f4f7db0773084e107730ecf3472f1dfe9ad583f3d9"},
+    {file = "msgpack-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:196a736f0526a03653d829d7d4c5500a97eea3648aebfd4b6743875f28aa2af8"},
+    {file = "msgpack-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d592d06e3cc2f537ceeeb23d38799c6ad83255289bb84c2e5792e5a8dea268a"},
+    {file = "msgpack-1.1.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4df2311b0ce24f06ba253fda361f938dfecd7b961576f9be3f3fbd60e87130ac"},
+    {file = "msgpack-1.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e4141c5a32b5e37905b5940aacbc59739f036930367d7acce7a64e4dec1f5e0b"},
+    {file = "msgpack-1.1.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b1ce7f41670c5a69e1389420436f41385b1aa2504c3b0c30620764b15dded2e7"},
+    {file = "msgpack-1.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4147151acabb9caed4e474c3344181e91ff7a388b888f1e19ea04f7e73dc7ad5"},
+    {file = "msgpack-1.1.1-cp313-cp313-win32.whl", hash = "sha256:500e85823a27d6d9bba1d057c871b4210c1dd6fb01fbb764e37e4e8847376323"},
+    {file = "msgpack-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:6d489fba546295983abd142812bda76b57e33d0b9f5d5b71c09a583285506f69"},
+    {file = "msgpack-1.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bba1be28247e68994355e028dcd668316db30c1f758d3241a7b903ac78dcd285"},
+    {file = "msgpack-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8f93dcddb243159c9e4109c9750ba5b335ab8d48d9522c5308cd05d7e3ce600"},
+    {file = "msgpack-1.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fbbc0b906a24038c9958a1ba7ae0918ad35b06cb449d398b76a7d08470b0ed9"},
+    {file = "msgpack-1.1.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:61e35a55a546a1690d9d09effaa436c25ae6130573b6ee9829c37ef0f18d5e78"},
+    {file = "msgpack-1.1.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:1abfc6e949b352dadf4bce0eb78023212ec5ac42f6abfd469ce91d783c149c2a"},
+    {file = "msgpack-1.1.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:996f2609ddf0142daba4cefd767d6db26958aac8439ee41db9cc0db9f4c4c3a6"},
+    {file = "msgpack-1.1.1-cp38-cp38-win32.whl", hash = "sha256:4d3237b224b930d58e9d83c81c0dba7aacc20fcc2f89c1e5423aa0529a4cd142"},
+    {file = "msgpack-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:da8f41e602574ece93dbbda1fab24650d6bf2a24089f9e9dbb4f5730ec1e58ad"},
+    {file = "msgpack-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f5be6b6bc52fad84d010cb45433720327ce886009d862f46b26d4d154001994b"},
+    {file = "msgpack-1.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3a89cd8c087ea67e64844287ea52888239cbd2940884eafd2dcd25754fb72232"},
+    {file = "msgpack-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d75f3807a9900a7d575d8d6674a3a47e9f227e8716256f35bc6f03fc597ffbf"},
+    {file = "msgpack-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d182dac0221eb8faef2e6f44701812b467c02674a322c739355c39e94730cdbf"},
+    {file = "msgpack-1.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b13fe0fb4aac1aa5320cd693b297fe6fdef0e7bea5518cbc2dd5299f873ae90"},
+    {file = "msgpack-1.1.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:435807eeb1bc791ceb3247d13c79868deb22184e1fc4224808750f0d7d1affc1"},
+    {file = "msgpack-1.1.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:4835d17af722609a45e16037bb1d4d78b7bdf19d6c0128116d178956618c4e88"},
+    {file = "msgpack-1.1.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a8ef6e342c137888ebbfb233e02b8fbd689bb5b5fcc59b34711ac47ebd504478"},
+    {file = "msgpack-1.1.1-cp39-cp39-win32.whl", hash = "sha256:61abccf9de335d9efd149e2fff97ed5974f2481b3353772e8e2dd3402ba2bd57"},
+    {file = "msgpack-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:40eae974c873b2992fd36424a5d9407f93e97656d999f43fca9d29f820899084"},
+    {file = "msgpack-1.1.1.tar.gz", hash = "sha256:77b79ce34a2bdab2594f490c8e80dd62a02d650b91a75159a63ec413b8d104cd"},
 ]
 
 [[package]]
@@ -3670,7 +3769,7 @@ version = "1.4.2"
 description = "Appendable key-value storage"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f"},
     {file = "partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c"},
@@ -4492,17 +4591,17 @@ googleapis-common-protos = {version = ">=1.56.4", optional = true, markers = "ex
 grpcio = {version = ">=1.56.0", optional = true, markers = "extra == \"connect\""}
 grpcio-status = {version = ">=1.56.0", optional = true, markers = "extra == \"connect\""}
 numpy = [
-    {version = ">=1.15,<2", optional = true, markers = "extra == \"connect\""},
     {version = ">=1.15,<2", optional = true, markers = "extra == \"pandas_on_spark\""},
+    {version = ">=1.15,<2", optional = true, markers = "extra == \"connect\""},
 ]
 pandas = [
-    {version = ">=1.0.5", optional = true, markers = "extra == \"connect\""},
     {version = ">=1.0.5", optional = true, markers = "extra == \"pandas_on_spark\""},
+    {version = ">=1.0.5", optional = true, markers = "extra == \"connect\""},
 ]
 py4j = "0.10.9.7"
 pyarrow = [
-    {version = ">=4.0.0", optional = true, markers = "extra == \"connect\""},
     {version = ">=4.0.0", optional = true, markers = "extra == \"pandas_on_spark\""},
+    {version = ">=4.0.0", optional = true, markers = "extra == \"connect\""},
 ]
 
 [package.extras]
@@ -5326,6 +5425,18 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.6"
 description = "A modern CSS selector implementation for Beautiful Soup."
@@ -5747,6 +5858,18 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
+name = "tblib"
+version = "3.1.0"
+description = "Traceback serialization library."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "tblib-3.1.0-py3-none-any.whl", hash = "sha256:670bb4582578134b3d81a84afa1b016128b429f3d48e6cbbaecc9d15675e984e"},
+    {file = "tblib-3.1.0.tar.gz", hash = "sha256:06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 description = "A lil' TOML parser"
@@ -5795,7 +5918,7 @@ version = "1.0.0"
 description = "List processing tools and functional utilities"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236"},
     {file = "toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02"},
@@ -6501,6 +6624,18 @@ docs = ["numcodecs[msgpack]", "numpydoc", "pydata-sphinx-theme", "sphinx", "sphi
 jupyter = ["ipytree (>=0.2.2)", "ipywidgets (>=8.0.0)", "notebook"]
 
 [[package]]
+name = "zict"
+version = "3.0.0"
+description = "Mutable mapping tools"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "zict-3.0.0-py2.py3-none-any.whl", hash = "sha256:5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae"},
+    {file = "zict-3.0.0.tar.gz", hash = "sha256:e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5"},
+]
+
+[[package]]
 name = "zipp"
 version = "3.21.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -6524,4 +6659,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7be4ef14b4cfc7865e032c66d9b6c15ada6742dd684730df549e03989648260a"
+content-hash = "196010293864105ac0cfe8c50b5f691c6b4ddd3807dcd2d937889b17519bb73d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ sphinx-autoapi = "3.0.0"
 pydata-sphinx-theme = "^0.16.0"
 sphinx-autobuild = "^2024.10.3"
 tomli = "^2.2.1"
+dask = {extras = ["distributed"], version = "^2025.5.1"}
 
 
 [tool.numpydoc_validation]

--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -444,7 +444,7 @@ class Fetch:
         variable_name: ForcingVariablesEnum,
         start_date: Union[str, datetime, pd.Timestamp],
         end_date: Union[str, datetime, pd.Timestamp],
-        calculate_zonal_weights: bool = True,
+        calculate_zonal_weights: bool = False,
         overwrite_output: Optional[bool] = False,
         chunk_by: Optional[NWMChunkByEnum] = None,
         domain: Optional[SupportedNWMRetroDomainsEnum] = "CONUS",
@@ -494,7 +494,7 @@ class Fetch:
             - v3.0: 2023-01-31
         calculate_zonal_weights : bool
             Flag specifying whether or not to calculate zonal weights.
-            True = calculate; False = use existing file. Default is True.
+            True = calculate; False = use existing file. Default is False.
         location_id_prefix : Optional[str]
             Prefix to include when filtering the locations table for polygon
             primary_location_id. Default is None, all locations are included.
@@ -908,7 +908,7 @@ class Fetch:
         start_date: Union[str, datetime, pd.Timestamp],
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         ingest_days: Optional[int] = None,
-        calculate_zonal_weights: bool = True,
+        calculate_zonal_weights: bool = False,
         location_id_prefix: Optional[str] = None,
         data_source: Optional[SupportedNWMDataSourcesEnum] = "GCS",
         kerchunk_method: Optional[SupportedKerchunkMethod] = "local",
@@ -974,7 +974,7 @@ class Fetch:
             If both are provided, ingest_days takes precedence.
         calculate_zonal_weights : bool
             Flag specifying whether or not to calculate zonal weights.
-            True = calculate; False = use existing file. Default is True.
+            True = calculate; False = use existing file. Default is False.
         location_id_prefix : Optional[str]
             Prefix to include when filtering the locations table for polygon
             primary_location_id. Default is None, all locations are included.

--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -838,7 +838,7 @@ class Fetch:
 
         ev_variable_name = format_nwm_variable_name(variable_name)
         ev_config = format_nwm_configuration_metadata(
-            nwm_configuration_name=nwm_configuration,
+            nwm_config_name=nwm_configuration,
             nwm_version=nwm_version
         )
 
@@ -1109,7 +1109,7 @@ class Fetch:
         """ # noqa
         ev_variable_name = format_nwm_variable_name(variable_name)
         ev_config = format_nwm_configuration_metadata(
-            nwm_configuration_name=nwm_configuration,
+            nwm_config_name=nwm_configuration,
             nwm_version=nwm_version
         )
 

--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -18,7 +18,7 @@ from teehr.loading.timeseries import (
 )
 from teehr.fetching.utils import (
     format_nwm_variable_name,
-    format_nwm_configuration_name
+    format_nwm_configuration_metadata
 )
 from teehr.models.fetching.nwm22_grid import ForcingVariablesEnum
 from teehr.models.fetching.utils import (
@@ -261,7 +261,7 @@ class Fetch:
                 Configuration(
                     name=USGS_CONFIGURATION_NAME,
                     type="primary",
-                    description="USGS Observations"
+                    description="USGS streamflow gauge observations"
                 )
             )
 
@@ -837,7 +837,7 @@ class Fetch:
         )
 
         ev_variable_name = format_nwm_variable_name(variable_name)
-        ev_config = format_nwm_configuration_name(
+        ev_config = format_nwm_configuration_metadata(
             nwm_configuration_name=nwm_configuration,
             nwm_version=nwm_version
         )
@@ -856,7 +856,7 @@ class Fetch:
             json_dir=self.kerchunk_cache_dir,
             output_parquet_dir=Path(
                 self.nwm_cache_dir,
-                ev_config["configuration_name"],
+                ev_config["name"],
                 ev_variable_name
             ),
             nwm_version=nwm_version,
@@ -877,14 +877,14 @@ class Fetch:
 
         if (
             not self._configuration_name_exists(
-                ev_config["configuration_name"]
+                ev_config["name"]
             )
         ):
             self.ev.configurations.add(
                 Configuration(
-                    name=ev_config["configuration_name"],
+                    name=ev_config["name"],
                     type=timeseries_type,
-                    description=f"{nwm_version} operational forecasts"
+                    description=ev_config["description"]
                 )
             )
 
@@ -1108,7 +1108,7 @@ class Fetch:
         :func:`teehr.fetching.nwm.nwm_grids.nwm_grids_to_parquet`
         """ # noqa
         ev_variable_name = format_nwm_variable_name(variable_name)
-        ev_config = format_nwm_configuration_name(
+        ev_config = format_nwm_configuration_metadata(
             nwm_configuration_name=nwm_configuration,
             nwm_version=nwm_version
         )
@@ -1120,7 +1120,7 @@ class Fetch:
         remove_dir_if_exists(self.nwm_cache_dir)
 
         ev_weights_cache_dir = Path(
-            self.weights_cache_dir, ev_config["configuration_name"]
+            self.weights_cache_dir, ev_config["name"]
         )
         ev_weights_cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1142,7 +1142,7 @@ class Fetch:
         if zonal_weights_filepath is None:
             zonal_weights_filepath = Path(
                 ev_weights_cache_dir,
-                f"{ev_config['configuration_name']}_pixel_weights.parquet"
+                f"{ev_config['name']}_pixel_weights.parquet"
             )
 
         nwm_grids_to_parquet(
@@ -1155,7 +1155,7 @@ class Fetch:
             json_dir=self.kerchunk_cache_dir,
             output_parquet_dir=Path(
                 self.nwm_cache_dir,
-                ev_config["configuration_name"],
+                ev_config["name"],
                 ev_variable_name
             ),
             nwm_version=nwm_version,
@@ -1179,14 +1179,14 @@ class Fetch:
 
         if (
             not self._configuration_name_exists(
-                ev_config["configuration_name"]
+                ev_config["name"]
             )
         ):
             self.ev.configurations.add(
                 Configuration(
-                    name=ev_config["configuration_name"],
+                    name=ev_config["name"],
                     type=timeseries_type,
-                    description=f"{nwm_version} operational forecasts"
+                    description=ev_config["description"]
                 )
             )
 

--- a/src/teehr/evaluation/tables/base_table.py
+++ b/src/teehr/evaluation/tables/base_table.py
@@ -107,7 +107,6 @@ class BaseTable():
         path = to_path_or_s3path(path)
 
         path = path_to_spark(path, pattern)
-
         # First, read the file with the schema and check if it's empty.
         # If it's not empty and it's the joined timeseries table,
         # read it again without the schema to ensure all fields are included.
@@ -148,7 +147,6 @@ class BaseTable():
     def _upsert_without_duplicates(
         self,
         df,
-        drop_duplicates: bool,
         num_partitions: int = None,
         **kwargs
     ):
@@ -175,11 +173,6 @@ class BaseTable():
                 existing_sdf = existing_sdf.filter(
                     col(partition).isin(partition_values)
                 )
-
-        # Drop potential duplicates in the cached dataframe
-        if drop_duplicates:
-            df = df.dropDuplicates(subset=self.unique_column_set)
-
         # Remove rows from existing_sdf that are to be updated.
         # Concat and re-write.
         if not existing_sdf.isEmpty():
@@ -212,7 +205,6 @@ class BaseTable():
     def _append_without_duplicates(
         self,
         df,
-        drop_duplicates: bool,
         num_partitions: int = None,
         **kwargs
     ):
@@ -230,11 +222,6 @@ class BaseTable():
             show_missing_table_warning=False,
             **kwargs
         )
-
-        # Drop potential duplicates in the cached dataframe
-        if drop_duplicates:
-            df = df.dropDuplicates(subset=self.unique_column_set)
-
         # Anti-join: Joins rows from left df that do not have a match
         # in right df.  This is used to drop duplicates. df gets written
         # in append mode.
@@ -244,7 +231,6 @@ class BaseTable():
             join_condition = reduce(
                 lambda x, y: x & y, [df[k].eqNullSafe(existing_sdf[k]) for k in self.unique_column_set]  # noqa: E501
             )
-
             df = df.join(
                 existing_sdf,
                 how="left_anti",
@@ -274,7 +260,6 @@ class BaseTable():
     def _dynamic_overwrite(
         self,
         df: ps.DataFrame,
-        drop_duplicates: bool,
         **kwargs
     ):
         """Overwrite partitions contained in the dataframe."""
@@ -284,9 +269,6 @@ class BaseTable():
         partition_by = self.partition_by
         if partition_by is None:
             partition_by = []
-        # Drop potential duplicates in the cached dataframe
-        if drop_duplicates:
-            df = df.dropDuplicates(subset=self.unique_column_set)
         (
             df.
             write.
@@ -302,7 +284,6 @@ class BaseTable():
         df: ps.DataFrame,
         write_mode: TableWriteEnum = "append",
         num_partitions: int = None,
-        drop_duplicates: bool = True,
         **kwargs
     ):
         """Write spark dataframe to directory.
@@ -328,20 +309,17 @@ class BaseTable():
         if write_mode == "overwrite":
             self._dynamic_overwrite(
                 df,
-                drop_duplicates=drop_duplicates,
                 **kwargs
             )
         elif write_mode == "append":
             self._append_without_duplicates(
                 df=df,
-                drop_duplicates=drop_duplicates,
                 num_partitions=num_partitions,
                 **kwargs
             )
         elif write_mode == "upsert":
             self._upsert_without_duplicates(
                 df=df,
-                drop_duplicates=drop_duplicates,
                 num_partitions=num_partitions,
                 **kwargs
             )
@@ -370,7 +348,8 @@ class BaseTable():
         self,
         df: ps.DataFrame,
         strict: bool = True,
-        add_missing_columns: bool = False
+        add_missing_columns: bool = False,
+        drop_duplicates: bool = True,
     ) -> ps.DataFrame:
         """Validate a DataFrame against the table schema.
 
@@ -402,6 +381,9 @@ class BaseTable():
 
         if strict:
             df = df.select(*schema_cols)
+
+        if drop_duplicates:
+            df = df.dropDuplicates(subset=self.unique_column_set)
 
         validated_df = schema.validate(df)
 

--- a/src/teehr/evaluation/tables/domain_table.py
+++ b/src/teehr/evaluation/tables/domain_table.py
@@ -30,6 +30,9 @@ class DomainTable(BaseTable):
         new_df = self.spark.createDataFrame(pd.DataFrame([o.model_dump() for o in obj]))
 
         combined_df = org_df.unionByName(new_df).repartition(1)
-        validated_df = self._validate(combined_df)
+        validated_df = self._validate(
+            df=combined_df,
+            drop_duplicates=True
+        )
 
         self._write_spark_df(validated_df)

--- a/src/teehr/evaluation/tables/joined_timeseries_table.py
+++ b/src/teehr/evaluation/tables/joined_timeseries_table.py
@@ -153,10 +153,13 @@ class JoinedTimeseriesTable(TimeseriesTable):
     def write(self, drop_duplicates: bool = False):
         """Write the joined timeseries table to disk."""
         # Validate to fix 'Cannot use NullType for partition column' error.
-        validated_df = self._validate(self.df, False)
+        validated_df = self._validate(
+            df=self.df,
+            strict=False,
+            drop_duplicates=drop_duplicates
+        )
         self._write_spark_df(
             validated_df,
-            drop_duplicates=drop_duplicates,
             write_mode="overwrite",
         )
         logger.info("Joined timeseries table written to disk.")
@@ -200,10 +203,13 @@ class JoinedTimeseriesTable(TimeseriesTable):
         if execute_scripts:
             joined_df = self._run_script(joined_df)
 
-        validated_df = self._validate(joined_df, False)
+        validated_df = self._validate(
+            df=joined_df,
+            strict=False,
+            drop_duplicates=drop_duplicates
+        )
         self._write_spark_df(
             validated_df,
-            drop_duplicates=drop_duplicates,
             write_mode="overwrite",
         )
         logger.info("Joined timeseries table created.")

--- a/src/teehr/evaluation/tables/location_attribute_table.py
+++ b/src/teehr/evaluation/tables/location_attribute_table.py
@@ -84,15 +84,17 @@ class LocationAttributeTable(BaseTable):
                 prefix=location_id_prefix,
             )
 
-        # Validate using the validate method
-        validated_df = self._validate(df)
+        # Validate using the _validate() method
+        validated_df = self._validate(
+            df=df,
+            drop_duplicates=drop_duplicates
+        )
 
         # Write to the table df.rdd.getNumPartitions()
         self._write_spark_df(
             df=validated_df,
             num_partitions=df.rdd.getNumPartitions(),
-            write_mode=write_mode,
-            drop_duplicates=drop_duplicates,
+            write_mode=write_mode
         )
 
         # Reload the table

--- a/src/teehr/evaluation/tables/location_crosswalk_table.py
+++ b/src/teehr/evaluation/tables/location_crosswalk_table.py
@@ -87,15 +87,17 @@ class LocationCrosswalkTable(BaseTable):
                 prefix=secondary_location_id_prefix,
             )
 
-        # Validate using the validate method
-        validated_df = self._validate(df)
+        # Validate using the _validate() method
+        validated_df = self._validate(
+            df=df,
+            drop_duplicates=drop_duplicates
+        )
 
         # Write to the table df.rdd.getNumPartitions()
         self._write_spark_df(
             df=validated_df,
             num_partitions=df.rdd.getNumPartitions(),
-            write_mode=write_mode,
-            drop_duplicates=drop_duplicates,
+            write_mode=write_mode
         )
 
         # Reload the table

--- a/src/teehr/evaluation/tables/location_table.py
+++ b/src/teehr/evaluation/tables/location_table.py
@@ -140,15 +140,17 @@ class LocationTable(BaseTable):
                 prefix=location_id_prefix,
             )
 
-        # Validate using the validate method
-        validated_df = self._validate(df)
+        # Validate using the _validate() method
+        validated_df = self._validate(
+            df=df,
+            drop_duplicates=drop_duplicates
+        )
 
         # Write to the table
         self._write_spark_df(
             df=validated_df,
             write_mode=write_mode,
-            num_partitions=1,
-            drop_duplicates=drop_duplicates,
+            num_partitions=1
         )
 
         # Reload the table

--- a/src/teehr/evaluation/tables/primary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/primary_timeseries_table.py
@@ -109,13 +109,15 @@ class PrimaryTimeseriesTable(TimeseriesTable):
             )
 
         # Validate using the _validate() method
-        validated_df = self._validate(df)
+        validated_df = self._validate(
+            df=df,
+            drop_duplicates=drop_duplicates
+        )
 
         # Write to the table
         self._write_spark_df(
             validated_df,
-            write_mode=write_mode,
-            drop_duplicates=drop_duplicates,
+            write_mode=write_mode
         )
 
         # Reload the table

--- a/src/teehr/evaluation/tables/secondary_timeseries_table.py
+++ b/src/teehr/evaluation/tables/secondary_timeseries_table.py
@@ -115,13 +115,15 @@ class SecondaryTimeseriesTable(TimeseriesTable):
             )
 
         # Validate using the _validate() method
-        validated_df = self._validate(df)
+        validated_df = self._validate(
+            df=df,
+            drop_duplicates=drop_duplicates
+        )
 
         # Write to the table
         self._write_spark_df(
             validated_df,
-            write_mode=write_mode,
-            drop_duplicates=drop_duplicates,
+            write_mode=write_mode
         )
 
         # Reload the table

--- a/src/teehr/fetching/const.py
+++ b/src/teehr/fetching/const.py
@@ -36,6 +36,14 @@ USGS_VARIABLE_MAPPER = {
     },
 }
 
+NWM_CONFIGURATION_DESCRIPTIONS = {
+    "analysis_assim_extend_no_da": "NWM analysis extended - no nudging - STAGE IV forcing",
+    "analysis_assim_extend": "NWM analysis extended - with nudging - STAGE IV forcing",
+    "medium_range_mem1": "NWM medium range - GFS member 1 forcing",
+    "medium_range_blend": "NWM medium range - NBM forcing",
+    "short_range": "NWM short range - HRRR forcing"
+}
+
 NWM_VARIABLE_MAPPER = {
     VARIABLE_NAME: {
         "streamflow": "streamflow_hourly_inst",

--- a/src/teehr/fetching/const.py
+++ b/src/teehr/fetching/const.py
@@ -39,7 +39,7 @@ USGS_VARIABLE_MAPPER = {
 NWM_CONFIGURATION_DESCRIPTIONS = {
     "analysis_assim_extend_no_da": "NWM analysis extended - no nudging - STAGE IV forcing",
     "analysis_assim_extend": "NWM analysis extended - with nudging - STAGE IV forcing",
-    "medium_range_mem1": "NWM medium range - GFS member 1 forcing",
+    "medium_range_mem": "NWM medium range - GFS forcing member",
     "medium_range_blend": "NWM medium range - NBM forcing",
     "short_range": "NWM short range - HRRR forcing"
 }

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -120,7 +120,7 @@ def process_single_nwm_grid_file(
     ds = get_dataset(
         row.filepath,
         ignore_missing_file,
-        target_options={'anon': True}
+        remote_options={"token": "anon"}
     )
     if not ds:
         return None

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -203,7 +203,7 @@ def fetch_and_format_nwm_grids(
     gps = df_refs.groupby(["day", "z_hour"])
 
     teehr_config = format_nwm_configuration_metadata(
-        nwm_configuration_name=nwm_configuration_name,
+        nwm_config_name=nwm_configuration_name,
         nwm_version=nwm_version
     )
 

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -215,7 +215,7 @@ def fetch_and_format_nwm_grids(
             results.append(
                 process_single_nwm_grid_file(
                     row,
-                    teehr_config["configuration_name"],
+                    teehr_config["name"],
                     variable_name,
                     zonal_weights_filepath,
                     ignore_missing_file,

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -12,7 +12,7 @@ from teehr.fetching.utils import (
     get_dataset,
     write_timeseries_parquet_file,
     parse_nwm_json_paths,
-    format_nwm_configuration_name
+    format_nwm_configuration_metadata
 )
 from teehr.models.fetching.utils import TimeseriesTypeEnum
 from teehr.fetching.const import (
@@ -202,7 +202,7 @@ def fetch_and_format_nwm_grids(
 
     gps = df_refs.groupby(["day", "z_hour"])
 
-    teehr_config = format_nwm_configuration_name(
+    teehr_config = format_nwm_configuration_metadata(
         nwm_configuration_name=nwm_configuration_name,
         nwm_version=nwm_version
     )

--- a/src/teehr/fetching/nwm/nwm_points.py
+++ b/src/teehr/fetching/nwm/nwm_points.py
@@ -3,6 +3,7 @@ from typing import Union, Optional, List, Dict, Annotated
 from datetime import datetime
 from pathlib import Path
 import logging
+import pandas as pd
 
 from pydantic import validate_call, Field
 
@@ -14,7 +15,8 @@ from teehr.fetching.utils import (
     build_remote_nwm_filelist,
     validate_operational_start_end_date,
     start_on_z_hour,
-    end_on_z_hour
+    end_on_z_hour,
+    get_end_date_from_ingest_days
 )
 from teehr.models.fetching.utils import (
     SupportedNWMOperationalVersionsEnum,
@@ -32,20 +34,21 @@ from teehr.fetching.const import (
 logger = logging.getLogger(__name__)
 
 
-@validate_call()
+@validate_call(config=dict(arbitrary_types_allowed=True))
 def nwm_to_parquet(
     configuration: str,
     output_type: str,
     variable_name: str,
-    start_date: Union[str, datetime],
-    ingest_days: int,
     location_ids: List[int],
     json_dir: Union[str, Path],
     output_parquet_dir: Union[str, Path],
     nwm_version: SupportedNWMOperationalVersionsEnum,
+    start_date: Union[str, datetime, pd.Timestamp],
+    end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
+    ingest_days: Optional[int] = None,
     data_source: Optional[SupportedNWMDataSourcesEnum] = "GCS",
     kerchunk_method: Optional[SupportedKerchunkMethod] = "local",
-    prioritize_analysis_valid_time: Optional[bool] = False,
+    prioritize_analysis_value_time: Optional[bool] = False,
     t_minus_hours: Optional[List[int]] = None,
     process_by_z_hour: Optional[bool] = True,
     stepsize: Optional[int] = 100,
@@ -54,7 +57,8 @@ def nwm_to_parquet(
     variable_mapper: Dict[str, Dict[str, str]] = None,
     timeseries_type: TimeseriesTypeEnum = "secondary",
     starting_z_hour: Optional[Annotated[int, Field(ge=0, le=23)]] = None,
-    ending_z_hour: Optional[Annotated[int, Field(ge=0, le=23)]] = None
+    ending_z_hour: Optional[Annotated[int, Field(ge=0, le=23)]] = None,
+    drop_overlapping_assimilation_values: Optional[bool] = True
 ):
     """Fetch NWM point data and save as a Parquet file in TEEHR format.
 
@@ -69,11 +73,6 @@ def nwm_to_parquet(
     variable_name : str
         Name of the NWM data variable to download.
         (e.g., "streamflow", "velocity", ...).
-    start_date : str or datetime
-        Date to begin data ingest.
-        Str formats can include YYYY-MM-DD or MM/DD/YYYY.
-    ingest_days : int
-        Number of days to ingest data after start date.
     location_ids : List[int]
         Array specifying NWM IDs of interest.
     json_dir : str
@@ -93,6 +92,17 @@ def nwm_to_parquet(
         - v2.0: 2019-06-19 - 2021-04-19
         - v2.1/2.2: 2021-04-20 - 2023-09-18
         - v3.0: 2023-09-19 - present
+    start_date : Union[str, datetime, pd.Timestamp]
+        Date to begin data ingest.
+        Str formats can include YYYY-MM-DD or MM/DD/YYYY.
+        Rounds down to beginning of day.
+    end_date : Union[str, datetime, pd.Timestamp],
+        Last date to fetch.  Rounds up to end of day.
+        Str formats can include YYYY-MM-DD or MM/DD/YYYY.
+    ingest_days : int
+        Number of days to ingest data after start date. This is deprecated
+        in favor of end_date, and will be removed in a future release.
+        If both are provided, ingest_days takes precedence.
     data_source : Optional[SupportedNWMDataSourcesEnum]
         Specifies the remote location from which to fetch the data
         "GCS" (default), "NOMADS", or "DSTOR"
@@ -105,7 +115,7 @@ def nwm_to_parquet(
         CIROH pre-generated jsons from s3, ignoring any that are unavailable.
         "auto" - read the CIROH pre-generated jsons from s3, and create any that
         are unavailable, storing locally.
-    prioritize_analysis_valid_time : Optional[bool]
+    prioritize_analysis_value_time : Optional[bool]
         A boolean flag that determines the method of fetching analysis data.
         When False (default), all hours of the reference time are included in the
         output. When True, only the hours within t_minus_hours are included.
@@ -138,6 +148,10 @@ def nwm_to_parquet(
     ending_z_hour : Optional[int]
         The ending z_hour to include in the output. If None, all z_hours
         are included for the last day. Default is None. Must be between 0 and 23.
+    drop_overlapping_assimilation_values: Optional[bool] = True
+        Whether to drop overlapping assimilation values. Default is True.
+        If True, values that overlap in value_time are dropped, keeping values with
+        the most recent reference_time. If False, overlapping values are kept.
 
     Notes
     -----
@@ -166,7 +180,7 @@ def nwm_to_parquet(
     >>> OUTPUT_TYPE = "channel_rt"
     >>> VARIABLE_NAME = "streamflow"
     >>> START_DATE = "2023-03-18"
-    >>> INGEST_DAYS = 1
+    >>> END_DATE = "2023-03-18"
     >>> JSON_DIR = Path(Path.home(), "temp/parquet/jsons/")
     >>> OUTPUT_DIR = Path(Path.home(), "temp/parquet")
     >>> NWM_VERSION = "nwm22"
@@ -186,7 +200,7 @@ def nwm_to_parquet(
     >>>     output_type=OUTPUT_TYPE,
     >>>     variable_name=VARIABLE_NAME,
     >>>     start_date=START_DATE,
-    >>>     ingest_days=INGEST_DAYS,
+    >>>     end_date=END_DATE,
     >>>     location_ids=LOCATION_IDS,
     >>>     json_dir=JSON_DIR,
     >>>     output_parquet_dir=OUTPUT_DIR,
@@ -201,6 +215,16 @@ def nwm_to_parquet(
     >>> )
     """ # noqa
     logger.info(f"Fetching {configuration} data. Version: {nwm_version}")
+
+    if ingest_days is not None:
+        end_date = get_end_date_from_ingest_days(
+            start_date=start_date,
+            ingest_days=ingest_days
+        )
+    elif end_date is None:
+        raise ValueError(
+            "Either 'end_date' or 'ingest_days' must be specified."
+        )
 
     # Import appropriate config model and dicts based on NWM version
     if nwm_version == SupportedNWMOperationalVersionsEnum.nwm12:
@@ -251,7 +275,7 @@ def nwm_to_parquet(
         validate_operational_start_end_date(
             nwm_version,
             start_date,
-            ingest_days
+            end_date
         )
 
         # Build paths to netcdf files on GCS
@@ -259,11 +283,12 @@ def nwm_to_parquet(
             configuration,
             output_type,
             start_date,
-            ingest_days,
+            end_date,
             analysis_config_dict,
             t_minus_hours,
             ignore_missing_file,
-            prioritize_analysis_valid_time
+            prioritize_analysis_value_time,
+            drop_overlapping_assimilation_values
         )
 
         if starting_z_hour is not None:
@@ -275,8 +300,7 @@ def nwm_to_parquet(
 
         if ending_z_hour is not None:
             gcs_component_paths = end_on_z_hour(
-                start_date=start_date,
-                ingest_days=ingest_days,
+                end_date=end_date,
                 end_z_hour=ending_z_hour,
                 gcs_component_paths=gcs_component_paths
             )

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -70,7 +70,7 @@ def file_chunk_loop(
     num_vals = vals.size
 
     teehr_config = format_nwm_configuration_metadata(
-        nwm_configuration_name=configuration,
+        nwm_config_name=configuration,
         nwm_version=nwm_version
     )
 

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -1,7 +1,6 @@
 """Module defining shared functions for processing NWM point data."""
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
-import re
 
 import dask
 import numpy as np
@@ -12,7 +11,7 @@ from teehr.fetching.utils import (
     get_dataset,
     write_timeseries_parquet_file,
     split_dataframe,
-    format_nwm_configuration_name,
+    format_nwm_configuration_metadata,
     parse_nwm_json_paths
 )
 from teehr.models.fetching.utils import TimeseriesTypeEnum
@@ -70,7 +69,7 @@ def file_chunk_loop(
         [f"{nwm_version}-{feat_id}" for feat_id in feature_ids]
     num_vals = vals.size
 
-    teehr_config = format_nwm_configuration_name(
+    teehr_config = format_nwm_configuration_metadata(
         nwm_configuration_name=configuration,
         nwm_version=nwm_version
     )

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -80,7 +80,7 @@ def file_chunk_loop(
             REFERENCE_TIME: np.full(vals.shape, ref_time),
             LOCATION_ID: teehr_location_ids,
             VALUE_TIME: np.full(vals.shape, valid_time),
-            CONFIGURATION_NAME: num_vals * [teehr_config["configuration_name"]],
+            CONFIGURATION_NAME: num_vals * [teehr_config["name"]],
             VARIABLE_NAME: num_vals * [teehr_variable_name],
             UNIT_NAME: num_vals * [teehr_units],
             MEMBER: num_vals * [teehr_config["member"]]

--- a/src/teehr/fetching/nwm/retrospective_grids.py
+++ b/src/teehr/fetching/nwm/retrospective_grids.py
@@ -344,7 +344,7 @@ def nwm_retro_grids_to_parquet(
             if zone_polygons is None:
                 raise ValueError(
                     "The zone polygons must be provided"
-                    " to calculate zonal weights. Can be a GeoDataFame"
+                    " to calculate zonal weights. Can be a GeoDataFrame"
                     " or a filepath."
                 )
 

--- a/src/teehr/fetching/nwm/retrospective_points.py
+++ b/src/teehr/fetching/nwm/retrospective_points.py
@@ -75,42 +75,33 @@ logger = logging.getLogger(__name__)
 
 def validate_retrospective_start_end_date(
     nwm_version: SupportedNWMRetroVersionsEnum,
-    start_date: Union[str, datetime],
-    end_date: Union[str, datetime]
+    start_date:  pd.Timestamp,
+    end_date:  pd.Timestamp
 ):
     """Validate the start and end dates by NWM version."""
-    if nwm_version == SupportedNWMRetroVersionsEnum.nwm20:
-        if end_date <= start_date:
-            raise ValueError("start_date must be before end_date")
+    if end_date < start_date:
+        raise ValueError("start_date must be before end_date")
 
+    if nwm_version == SupportedNWMRetroVersionsEnum.nwm20:
         if start_date < NWM21_MIN_DATE:
             raise ValueError(
                 f"start_date must be on or after {NWM20_MIN_DATE}"
             )
-
         if end_date > NWM21_MAX_DATE:
             raise ValueError(f"end_date must be on or before {NWM20_MAX_DATE}")
 
     elif nwm_version == SupportedNWMRetroVersionsEnum.nwm21:
-        if end_date <= start_date:
-            raise ValueError("start_date must be before end_date")
-
         if start_date < NWM21_MIN_DATE:
             raise ValueError(
                 f"start_date must be on or after {NWM21_MIN_DATE}"
             )
-
         if end_date > NWM21_MAX_DATE:
             raise ValueError(f"end_date must be on or before {NWM21_MAX_DATE}")
     elif nwm_version == SupportedNWMRetroVersionsEnum.nwm30:
-        if end_date <= start_date:
-            raise ValueError("start_date must be before end_date")
-
         if start_date < NWM30_MIN_DATE:
             raise ValueError(
                 f"start_date must be on or after {NWM30_MIN_DATE}"
             )
-
         if end_date > NWM30_MAX_DATE:
             raise ValueError(f"end_date must be on or before {NWM30_MAX_DATE}")
     else:

--- a/src/teehr/fetching/utils.py
+++ b/src/teehr/fetching/utils.py
@@ -315,7 +315,9 @@ def _drop_nan_values(
         logger.debug(
             "NaN values were encountered, dropping from the dataframe."
         )
-        return df.dropna(subset=subset_columns).reset_index(drop=True)
+        df = df.dropna(subset=subset_columns).reset_index(drop=True)
+        if df.index.size == 0:
+            return None
     return df
 
 
@@ -346,6 +348,13 @@ def write_timeseries_parquet_file(
         df = data
 
     df = _drop_nan_values(df)
+
+    if df is None:
+        logger.warning(
+            f"The dataframe is empty after dropping NaN values; "
+            f"skipping writing to {filepath.name}."
+        )
+        return
 
     if timeseries_type == TimeseriesTypeEnum.primary:
         schema = schemas.primary_timeseries_schema(type="pandas")

--- a/src/teehr/fetching/utils.py
+++ b/src/teehr/fetching/utils.py
@@ -161,7 +161,7 @@ def parse_nwm_json_paths(
 
 
 def format_nwm_configuration_metadata(
-    nwm_configuration_name: str,
+    nwm_config_name: str,
     nwm_version: str
 ) -> Dict[str, str]:
     """Format the NWM configuration name and member for the Evaluation.
@@ -171,20 +171,27 @@ def format_nwm_configuration_metadata(
     (ie., medium range or long range streamflow).
     """
     logger.info(
-        f"Formatting configuration name for {nwm_configuration_name}."
+        f"Formatting configuration name for {nwm_config_name}."
     )
     ev_member = None
-    if bool(re.search(r"_mem[0-9]+", nwm_configuration_name)):
-        ev_configuration, ev_member = nwm_configuration_name.split("_mem")
+    # Try to parse the member from the configuration name.
+    if bool(re.search(r"_mem[0-9]+", nwm_config_name)):
+        ev_config_name, ev_member = nwm_config_name.split("_mem")
+        ev_config_name = nwm_version + "_" + ev_config_name
+        nwm_config_name = re.sub(r'\d+', '', nwm_config_name)
     else:
-        ev_configuration = nwm_configuration_name
-    ev_configuration = nwm_version + "_" + ev_configuration
-    if nwm_configuration_name in NWM_CONFIGURATION_DESCRIPTIONS:
-        ev_config_desc = NWM_CONFIGURATION_DESCRIPTIONS[nwm_configuration_name]
+        ev_config_name = nwm_version + "_" + nwm_config_name
+    # Get the config description.
+    if nwm_config_name in NWM_CONFIGURATION_DESCRIPTIONS:
+        if ev_member is not None:
+            ev_config_desc = NWM_CONFIGURATION_DESCRIPTIONS[nwm_config_name] \
+                + f" {ev_member}"
+        else:
+            ev_config_desc = NWM_CONFIGURATION_DESCRIPTIONS[nwm_config_name]
     else:
-        ev_config_desc = "NWM operational forecasts"
+        ev_config_desc = "NWM operational forecasts"  # default description
     return {
-        "name": ev_configuration,
+        "name": ev_config_name,
         "member": ev_member,
         "description": ev_config_desc
     }

--- a/src/teehr/fetching/utils.py
+++ b/src/teehr/fetching/utils.py
@@ -36,7 +36,8 @@ from teehr.fetching.const import (
     NWM20_START_DATE,
     NWM12_START_DATE,
     NWM_VARIABLE_MAPPER,
-    VARIABLE_NAME
+    VARIABLE_NAME,
+    NWM_CONFIGURATION_DESCRIPTIONS
 )
 import teehr.models.pandera_dataframe_schemas as schemas
 
@@ -159,7 +160,7 @@ def parse_nwm_json_paths(
     )
 
 
-def format_nwm_configuration_name(
+def format_nwm_configuration_metadata(
     nwm_configuration_name: str,
     nwm_version: str
 ) -> Dict[str, str]:
@@ -178,7 +179,15 @@ def format_nwm_configuration_name(
     else:
         ev_configuration = nwm_configuration_name
     ev_configuration = nwm_version + "_" + ev_configuration
-    return {"configuration_name": ev_configuration, "member": ev_member}
+    if nwm_configuration_name in NWM_CONFIGURATION_DESCRIPTIONS:
+        ev_config_desc = NWM_CONFIGURATION_DESCRIPTIONS[nwm_configuration_name]
+    else:
+        ev_config_desc = "NWM operational forecasts"
+    return {
+        "name": ev_configuration,
+        "member": ev_member,
+        "description": ev_config_desc
+    }
 
 
 def format_nwm_variable_name(variable_name: str) -> str:

--- a/src/teehr/loading/s3/clone_from_s3.py
+++ b/src/teehr/loading/s3/clone_from_s3.py
@@ -191,8 +191,7 @@ def clone_from_s3(
 
         table._write_spark_df(
             sdf_in,
-            write_mode="overwrite",
-            drop_duplicates=drop_duplicates,
+            write_mode="overwrite"
         )
 
     # copy scripts path to ev.scripts_dir

--- a/tests/data/test_study/timeseries/nwm_ana_timeseries_for_upsert.parquet
+++ b/tests/data/test_study/timeseries/nwm_ana_timeseries_for_upsert.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2428fe9f5009ffef58919c1c8d3b06b997ba2ee3761171f49ca419e7b4a06047
-size 7292
+oid sha256:a4da6eac0920fa929792b3dd325225b36d1a9dc0b9dd665023c28b83aefbf1cb
+size 6999

--- a/tests/notebooks/test_nwm_fetching.ipynb
+++ b/tests/notebooks/test_nwm_fetching.ipynb
@@ -107,9 +107,9 @@
     "        output_type=\"channel_rt\",\n",
     "        variable_name=\"streamflow\",\n",
     "        start_date=datetime(2024, 2, 22),\n",
-    "        ingest_days=1,\n",
+    "        end_date=datetime(2024, 2, 22),\n",
     "        nwm_version=\"nwm30\",\n",
-    "        prioritize_analysis_valid_time=True,\n",
+    "        prioritize_analysis_value_time=True,\n",
     "        t_minus_hours=[0],\n",
     "        process_by_z_hour=False\n",
     "    )\n",
@@ -166,7 +166,7 @@
     "        output_type=output_type,\n",
     "        variable_name=variable_name,\n",
     "        start_date=start_date,\n",
-    "        ingest_days=(end_date - start_date).days + 1,\n",
+    "        end_date=end_date,\n",
     "        location_ids=nwm_ids,\n",
     "        json_dir=Path(tempdir, \"kerchunk\", configuration),\n",
     "        output_parquet_dir=Path(tempdir, \"parquet\", configuration),\n",
@@ -206,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "teehr-UF_UIVrG-py3.12",
    "language": "python",
    "name": "python3"
   },
@@ -220,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/tests/test_fetch_and_load.py
+++ b/tests/test_fetch_and_load.py
@@ -141,13 +141,14 @@ def test_fetch_and_load_nwm_operational_points(tmpdir):
         output_type="channel_rt",
         variable_name="streamflow",
         start_date=datetime(2024, 2, 22),
+        end_date=datetime(2025, 2, 22),
         ingest_days=1,
         nwm_version="nwm30",
-        prioritize_analysis_valid_time=True,
+        prioritize_analysis_value_time=True,
         t_minus_hours=[0],
         process_by_z_hour=False,
         starting_z_hour=3,
-        ending_z_hour=20
+        ending_z_hour=20,
     )
     ts_df = ev.secondary_timeseries.to_pandas()
 
@@ -193,9 +194,10 @@ def test_fetch_and_load_nwm_operational_grids(tmpdir):
         output_type="forcing",
         variable_name="RAINRATE",
         start_date=datetime(2024, 2, 22),
+        end_date=datetime(2024, 2, 22),
         ingest_days=1,
         nwm_version="nwm30",
-        prioritize_analysis_valid_time=True,
+        prioritize_analysis_value_time=True,
         t_minus_hours=[0],
         location_id_prefix="huc10",
         calculate_zonal_weights=True,

--- a/tests/test_nwm_fetching_utils.py
+++ b/tests/test_nwm_fetching_utils.py
@@ -14,8 +14,8 @@ from teehr.fetching.utils import (
     create_periods_based_on_chunksize,
     parse_nwm_json_paths,
     start_on_z_hour,
-    end_on_z_hour
-
+    end_on_z_hour,
+    format_nwm_configuration_metadata
 )
 from teehr.fetching.const import (
     NWM22_ANALYSIS_CONFIG,
@@ -356,6 +356,62 @@ def test_start_end_z_hours():
     assert len(gcs_component_paths) == 612
 
 
+def test_nwm_configuration_metadata():
+    """Test the NWM configuration metadata."""
+    #
+    nwm_configuration_name = "short_range"
+    nwm_version = "nwm30"
+    config_meta = format_nwm_configuration_metadata(
+        nwm_config_name=nwm_configuration_name,
+        nwm_version=nwm_version
+    )
+    assert config_meta["name"] == "nwm30_short_range"
+    assert config_meta["description"] == "NWM short range - HRRR forcing"
+    assert config_meta["member"] == None
+    #
+    nwm_configuration_name = "analysis_assim_extend_no_da"
+    config_meta = format_nwm_configuration_metadata(
+        nwm_config_name=nwm_configuration_name,
+        nwm_version=nwm_version
+    )
+    assert config_meta["name"] == "nwm30_analysis_assim_extend_no_da"
+    assert config_meta["description"] == "NWM analysis extended - no nudging - STAGE IV forcing"
+    #
+    nwm_configuration_name = "analysis_assim_extend"
+    config_meta = format_nwm_configuration_metadata(
+        nwm_config_name=nwm_configuration_name,
+        nwm_version=nwm_version
+    )
+    assert config_meta["name"] == "nwm30_analysis_assim_extend"
+    assert config_meta["description"] == "NWM analysis extended - with nudging - STAGE IV forcing"
+    #
+    nwm_configuration_name = "medium_range_mem1"
+    config_meta = format_nwm_configuration_metadata(
+        nwm_config_name=nwm_configuration_name,
+        nwm_version=nwm_version
+    )
+    assert config_meta["name"] == "nwm30_medium_range"
+    assert config_meta["description"] == "NWM medium range - GFS forcing member 1"
+    assert config_meta["member"] == "1"
+    #
+    nwm_configuration_name = "medium_range_mem6"
+    config_meta = format_nwm_configuration_metadata(
+        nwm_config_name=nwm_configuration_name,
+        nwm_version=nwm_version
+    )
+    assert config_meta["name"] == "nwm30_medium_range"
+    assert config_meta["description"] == "NWM medium range - GFS forcing member 6"
+    assert config_meta["member"] == "6"
+    #
+    nwm_configuration_name = "medium_range_blend"
+    config_meta = format_nwm_configuration_metadata(
+        nwm_config_name=nwm_configuration_name,
+        nwm_version=nwm_version
+    )
+    assert config_meta["name"] == "nwm30_medium_range_blend"
+    assert config_meta["description"] == "NWM medium range - NBM forcing"
+
+
 if __name__ == "__main__":
     with tempfile.TemporaryDirectory(prefix="teehr-") as tempdir:
         test_parsing_remote_json_paths(tempdir)
@@ -374,3 +430,4 @@ if __name__ == "__main__":
     test_create_periods_based_on_month()
     test_create_periods_based_on_year()
     test_start_end_z_hours()
+    test_nwm_configuration_metadata()

--- a/tests/test_nwm_fetching_utils.py
+++ b/tests/test_nwm_fetching_utils.py
@@ -80,8 +80,8 @@ def test_dates_and_nwm30_version():
     """Make sure start/end dates work with specified NWM version."""
     nwm_version = "nwm30"
     start_date = "2023-11-20"
-    ingest_days = 1
-    validate_operational_start_end_date(nwm_version, start_date, ingest_days)
+    end_date = "2023-11-20"
+    validate_operational_start_end_date(nwm_version, start_date, end_date)
 
     try:
         failed = False
@@ -89,7 +89,7 @@ def test_dates_and_nwm30_version():
         validate_operational_start_end_date(
             nwm_version,
             start_date,
-            ingest_days
+            end_date
         )
     except ValueError:
         failed = True
@@ -100,16 +100,17 @@ def test_dates_and_nwm22_version():
     """Make sure start/end dates work with specified NWM version."""
     nwm_version = "nwm22"
     start_date = "2022-11-20"
-    ingest_days = 1
-    validate_operational_start_end_date(nwm_version, start_date, ingest_days)
+    end_date = "2022-11-20"
+    validate_operational_start_end_date(nwm_version, start_date, end_date)
 
     try:
         failed = False
         start_date = "2023-11-20"
+        end_date = "2025-11-20"
         validate_operational_start_end_date(
             nwm_version,
             start_date,
-            ingest_days
+            end_date
         )
     except ValueError:
         failed = True
@@ -120,8 +121,8 @@ def test_dates_and_nwm21_version():
     """Make sure start/end dates work with specified NWM version."""
     nwm_version = "nwm21"
     start_date = "2021-04-30"
-    ingest_days = 1
-    validate_operational_start_end_date(nwm_version, start_date, ingest_days)
+    end_date = "2021-04-30"
+    validate_operational_start_end_date(nwm_version, start_date, end_date)
 
     try:
         failed = False
@@ -129,7 +130,7 @@ def test_dates_and_nwm21_version():
         validate_operational_start_end_date(
             nwm_version,
             start_date,
-            ingest_days
+            end_date
         )
     except ValueError:
         failed = True
@@ -140,8 +141,8 @@ def test_dates_and_nwm20_version():
     """Make sure start/end dates work with specified NWM version."""
     nwm_version = "nwm20"
     start_date = "2019-06-20"
-    ingest_days = 1
-    validate_operational_start_end_date(nwm_version, start_date, ingest_days)
+    end_date = "2019-06-20"
+    validate_operational_start_end_date(nwm_version, start_date, end_date)
 
     try:
         failed = False
@@ -149,7 +150,7 @@ def test_dates_and_nwm20_version():
         validate_operational_start_end_date(
             nwm_version,
             start_date,
-            ingest_days
+            end_date
         )
     except ValueError:
         failed = True
@@ -160,8 +161,8 @@ def test_dates_and_nwm12_version():
     """Make sure start/end dates work with specified NWM version."""
     nwm_version = "nwm12"
     start_date = "2018-11-20"
-    ingest_days = 1
-    validate_operational_start_end_date(nwm_version, start_date, ingest_days)
+    end_date = "2018-11-20"
+    validate_operational_start_end_date(nwm_version, start_date, end_date)
 
     try:
         failed = False
@@ -169,7 +170,7 @@ def test_dates_and_nwm12_version():
         validate_operational_start_end_date(
             nwm_version,
             start_date,
-            ingest_days
+            end_date
         )
     except ValueError:
         failed = True
@@ -182,33 +183,45 @@ def test_building_nwm30_gcs_paths():
         configuration="forcing_analysis_assim_extend",
         output_type="forcing",
         start_dt="2023-11-28",
-        ingest_days=1,
+        end_dt="2023-11-29",
         analysis_config_dict=NWM30_ANALYSIS_CONFIG,
-        t_minus_hours=[0],
+        t_minus_hours=None,
         ignore_missing_file=False,
-        prioritize_analysis_valid_time=False
+        prioritize_analysis_value_time=False,
+        drop_overlapping_assimilation_values=True
     )
-    assert len(gcs_component_paths) == 28
-    assert all(
-        ["nwm.20231128/forcing_analysis_assim_extend/nwm.t16z.analysis_assim_extend.forcing" in path for path in gcs_component_paths]  # noqa
+    assert len(gcs_component_paths) == 52
+    assert (
+        gcs_component_paths[0] == \
+            'gcs://national-water-model/nwm.20231128/forcing_analysis_assim_extend/nwm.t16z.analysis_assim_extend.forcing.tm27.conus.nc' # noqa
+    )
+    assert (
+        gcs_component_paths[-1] == \
+            'gcs://national-water-model/nwm.20231129/forcing_analysis_assim_extend/nwm.t16z.analysis_assim_extend.forcing.tm00.conus.nc' # noqa
     )
 
 
 def test_building_nwm22_gcs_paths():
     """Test building NWM22 GCS paths."""
     gcs_component_paths = build_remote_nwm_filelist(
-        configuration="analysis_assim_extend",
+        configuration="analysis_assim",
         output_type="channel_rt",
         start_dt="2019-01-12",
-        ingest_days=1,
+        end_dt="2019-01-12",
         analysis_config_dict=NWM22_ANALYSIS_CONFIG,
         t_minus_hours=[0],
         ignore_missing_file=False,
-        prioritize_analysis_valid_time=True
+        prioritize_analysis_value_time=False,
+        drop_overlapping_assimilation_values=False
+    )
+    assert len(gcs_component_paths) == 24
+    assert (
+        gcs_component_paths[-1] == \
+            'gcs://national-water-model/nwm.20190112/analysis_assim/nwm.t23z.analysis_assim.channel_rt.tm00.conus.nc' # noqa
     )
     assert (
-        gcs_component_paths == \
-            ['gcs://national-water-model/nwm.20190112/analysis_assim_extend/nwm.t16z.analysis_assim_extend.channel_rt.tm00.conus.nc'] # noqa
+        gcs_component_paths[0] == \
+            'gcs://national-water-model/nwm.20190112/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm00.conus.nc' # noqa
     )
 
 
@@ -319,11 +332,12 @@ def test_start_end_z_hours():
         configuration="short_range",
         output_type="channel_rt",
         start_dt="2023-11-28",
-        ingest_days=2,
+        end_dt="2023-11-29",
         analysis_config_dict=NWM30_ANALYSIS_CONFIG,
         t_minus_hours=[0],
         ignore_missing_file=False,
-        prioritize_analysis_valid_time=False
+        prioritize_analysis_value_time=False,
+        drop_overlapping_assimilation_values=False
     )
 
     gcs_component_paths = start_on_z_hour(
@@ -334,8 +348,7 @@ def test_start_end_z_hours():
     gcs_component_paths = end_on_z_hour(
         gcs_component_paths=gcs_component_paths,
         end_z_hour=12,
-        ingest_days=2,
-        start_date=datetime.strptime("2023-11-28", "%Y-%m-%d")
+        end_date=datetime.strptime("2023-11-29", "%Y-%m-%d")
     )
 
     assert gcs_component_paths[-1] == 'gcs://national-water-model/nwm.20231129/short_range/nwm.t12z.short_range.channel_rt.f018.conus.nc'  # noqa


### PR DESCRIPTION
* Handles the case when all NaN values are returned from fetching NWM or USGS data. Previously an empty dataframe was written, which would fail on loading. Now no dataframe is written, so nothing is loaded, but it doesn't fail. fixes #441 
* Updates default NWM configuration descriptions, fixes #453 
* Updates default for `calculate_zonal_weights`, fixes #456 
* Adds `dask[distributed]` to python env in `dev` group for testing

Note. I merged #480 into this branch, we should probably merge 480 first