### PR TITLE
rename metric wrappers to improve clarity in the API

### DIFF
--- a/src/teehr/metrics/deterministic_funcs.py
+++ b/src/teehr/metrics/deterministic_funcs.py
@@ -98,99 +98,100 @@ def _root_mean_squared_error(p: pd.Series, s: pd.Series) -> float:
     return _mean_error(p, s, power=2.0, root=True)
 
 
-def me_wrapper(model: MetricsBasemodel) -> Callable:
-    """Create the mean_error metric function."""
+def mean_error(model: MetricsBasemodel) -> Callable:
+    """Create the Mean Error metric function."""
     logger.debug("Building the mean_error metric function")
 
-    def mean_error(p: pd.Series, s: pd.Series) -> float:
+    def mean_error_inner(p: pd.Series, s: pd.Series) -> float:
         """Mean Error."""
         p, s = _transform(p, s, model)
         difference = s - p
         return np.sum(difference)/len(p)
 
-    return mean_error
+    return mean_error_inner
 
 
-def rb_wrapper(model: MetricsBasemodel) -> Callable:
-    """Create the relative_bias metric function."""
+def relative_bias(model: MetricsBasemodel) -> Callable:
+    """Create the Relative Bias metric function."""
     logger.debug("Building the relative_bias metric function")
 
-    def relative_bias(p: pd.Series, s: pd.Series) -> float:
+    def relative_bias_inner(p: pd.Series, s: pd.Series) -> float:
         """Relative Bias."""
         p, s = _transform(p, s, model)
         difference = s - p
         return np.sum(difference)/np.sum(p)
 
-    return relative_bias
+    return relative_bias_inner
 
 
-def mare_wrapper(model: MetricsBasemodel) -> Callable:
-    """Create the mean_absolute_relative_error metric function."""
+def mean_absolute_relative_error(model: MetricsBasemodel) -> Callable:
+    """Create the Absolute Relative Error metric function."""
     logger.debug("Building the mean_absolute_relative_error metric function")
 
-    def mean_absolute_relative_error(p: pd.Series, s: pd.Series) -> float:
+    def mean_absolute_relative_error_inner(p: pd.Series,
+                                           s: pd.Series) -> float:
         """Absolute Relative Error."""
         p, s = _transform(p, s, model)
         absolute_difference = np.abs(s - p)
         return np.sum(absolute_difference)/np.sum(p)
 
-    return mean_absolute_relative_error
+    return mean_absolute_relative_error_inner
 
 
-def mb_wrapper(model: MetricsBasemodel) -> Callable:
-    """Create the multiplicative_bias metric function."""
+def multiplicative_bias(model: MetricsBasemodel) -> Callable:
+    """Create the Multiplicative Bias metric function."""
     logger.debug("Building the multiplicative_bias metric function")
 
-    def multiplicative_bias(p: pd.Series, s: pd.Series) -> float:
+    def multiplicative_bias_inner(p: pd.Series, s: pd.Series) -> float:
         """Multiplicative Bias."""
         p, s = _transform(p, s, model)
         return np.mean(s)/np.mean(p)
 
-    return multiplicative_bias
+    return multiplicative_bias_inner
 
 
-def pc_wrapper(model: MetricsBasemodel) -> Callable:
-    """Create the pearson_correlation metric function."""
+def pearson_correlation(model: MetricsBasemodel) -> Callable:
+    """Create the Pearson Correlation Coefficient metric function."""
     logger.debug("Building the pearson_correlation metric function")
 
-    def pearson_correlation(p: pd.Series, s: pd.Series) -> float:
+    def pearson_correlation_inner(p: pd.Series, s: pd.Series) -> float:
         """Pearson Correlation Coefficient."""
         p, s = _transform(p, s, model)
         return np.corrcoef(s, p)[0][1]
 
-    return pearson_correlation
+    return pearson_correlation_inner
 
 
-def r_squared_wrapper(model: MetricsBasemodel) -> Callable:
+def r_squared(model: MetricsBasemodel) -> Callable:
     """Create the R-squared metric function."""
     logger.debug("Building the R-squared metric function")
 
-    def r_squared(p: pd.Series, s: pd.Series) -> float:
+    def r_squared_inner(p: pd.Series, s: pd.Series) -> float:
         """R-squared."""
         p, s = _transform(p, s, model)
         pearson_correlation_coefficient = np.corrcoef(s, p)[0][1]
         return np.power(pearson_correlation_coefficient, 2)
 
-    return r_squared
+    return r_squared_inner
 
 
-def mvd_wrapper(model: MetricsBasemodel) -> Callable:
+def max_value_delta(model: MetricsBasemodel) -> Callable:
     """Create the max_value_delta metric function."""
     logger.debug("Building the max_value_delta metric function")
 
-    def max_value_delta(p: pd.Series, s: pd.Series) -> float:
+    def max_value_delta_inner(p: pd.Series, s: pd.Series) -> float:
         """Max value delta."""
         p, s = _transform(p, s, model)
         return np.max(s) - np.max(p)
 
-    return max_value_delta
+    return max_value_delta_inner
 
 
-def aprb_wrapper(model: MetricsBasemodel) -> Callable:
+def annual_peak_relative_bias(model: MetricsBasemodel) -> Callable:
     """Create the annual_peak_relative_bias metric function."""
     logger.debug("Building the annual_peak_relative_bias metric function")
 
-    def annual_peak_relative_bias(
+    def annual_peak_relative_bias_inner(
         p: pd.Series,
         s: pd.Series,
         value_time: pd.Series
@@ -215,14 +216,14 @@ def aprb_wrapper(model: MetricsBasemodel) -> Callable:
             - primary_yearly_max_values
             ) / np.sum(primary_yearly_max_values)
 
-    return annual_peak_relative_bias
+    return annual_peak_relative_bias_inner
 
 
-def spearman_wrapper(model: MetricsBasemodel) -> Callable:
+def spearman_correlation(model: MetricsBasemodel) -> Callable:
     """Create the Spearman metric function."""
     logger.debug("Building the spearman_correlation metric function")
 
-    def spearman_correlation(p: pd.Series, s: pd.Series) -> float:
+    def spearman_correlation_inner(p: pd.Series, s: pd.Series) -> float:
         """Spearman Rank Correlation Coefficient."""
         p, s = _transform(p, s, model)
 
@@ -234,14 +235,14 @@ def spearman_wrapper(model: MetricsBasemodel) -> Callable:
             / (count * (count**2 - 1))
             )
 
-    return spearman_correlation
+    return spearman_correlation_inner
 
 
-def nse_wrapper(model: MetricsBasemodel) -> Callable:
+def nash_sutcliffe_efficiency(model: MetricsBasemodel) -> Callable:
     """Create the nash_sutcliffe_efficiency metric function."""
     logger.debug("Building the nash_sutcliffe_efficiency metric function")
 
-    def nash_sutcliffe_efficiency(p: pd.Series, s: pd.Series) -> float:
+    def nash_sutcliffe_efficiency_inner(p: pd.Series, s: pd.Series) -> float:
         """Nash-Sutcliffe Efficiency."""
         if len(p) == 0 or len(s) == 0:
             return np.nan
@@ -258,18 +259,18 @@ def nse_wrapper(model: MetricsBasemodel) -> Callable:
             return np.nan
         return 1.0 - numerator/denominator
 
-    return nash_sutcliffe_efficiency
+    return nash_sutcliffe_efficiency_inner
 
 
-def nse_norm_wrapper(model: MetricsBasemodel) -> Callable:
+def nash_sutcliffe_efficiency_normalized(model: MetricsBasemodel) -> Callable:
     """Create the nash_sutcliffe_efficiency_normalized metric function."""
     logger.debug(
         "Building the nash_sutcliffe_efficiency_normalized metric function"
         )
 
-    def nash_sutcliffe_efficiency_normalized(p: pd.Series,
-                                             s: pd.Series
-                                             ) -> float:
+    def nash_sutcliffe_efficiency_normalized_inner(p: pd.Series,
+                                                   s: pd.Series
+                                                   ) -> float:
         """Apply normalized Nash-Sutcliffe Efficiency."""
         if len(p) == 0 or len(s) == 0:
             return np.nan
@@ -286,16 +287,16 @@ def nse_norm_wrapper(model: MetricsBasemodel) -> Callable:
             return np.nan
         return 1.0 / (1.0 + numerator/denominator)
 
-    return nash_sutcliffe_efficiency_normalized
+    return nash_sutcliffe_efficiency_normalized_inner
 
 
-def kge_wrapper(model: MetricsBasemodel) -> Callable:
+def kling_gupta_efficiency(model: MetricsBasemodel) -> Callable:
     """Create the kling_gupta_efficiency metric function."""
     logger.debug("Building the kling_gupta_efficiency metric function")
 
-    def kling_gupta_efficiency(p: pd.Series,
-                               s: pd.Series,
-                               ) -> float:
+    def kling_gupta_efficiency_inner(p: pd.Series,
+                                     s: pd.Series,
+                                     ) -> float:
         """Kling-Gupta Efficiency (2009)."""
         if np.std(s) == 0 or np.std(p) == 0:
             return np.nan
@@ -321,14 +322,14 @@ def kge_wrapper(model: MetricsBasemodel) -> Callable:
         # Return KGE
         return 1.0 - euclidean_distance
 
-    return kling_gupta_efficiency
+    return kling_gupta_efficiency_inner
 
 
-def kge_mod1_wrapper(model: MetricsBasemodel) -> Callable:
+def kling_gupta_efficiency_mod1(model: MetricsBasemodel) -> Callable:
     """Create the kling_gupta_efficiency_mod1 metric function."""
     logger.debug("Building the kling_gupta_effiency_mod1 metric function")
 
-    def kling_gupta_efficiency_mod1(p: pd.Series, s: pd.Series) -> float:
+    def kling_gupta_efficiency_mod1_inner(p: pd.Series, s: pd.Series) -> float:
         """Kling-Gupta Efficiency - modified 1 (2012)."""
         if np.std(s) == 0 or np.std(p) == 0:
             return np.nan
@@ -356,14 +357,14 @@ def kge_mod1_wrapper(model: MetricsBasemodel) -> Callable:
 
         return 1.0 - euclidean_distance
 
-    return kling_gupta_efficiency_mod1
+    return kling_gupta_efficiency_mod1_inner
 
 
-def kge_mod2_wrapper(model: MetricsBasemodel) -> Callable:
+def kling_gupta_efficiency_mod2(model: MetricsBasemodel) -> Callable:
     """Create the kling_gupta_efficiency_mod2 metric function."""
     logger.debug("Building the kling_gupta_efficiency_mod2 metric function")
 
-    def kling_gupta_efficiency_mod2(p: pd.Series, s: pd.Series) -> float:
+    def kling_gupta_efficiency_mod2_inner(p: pd.Series, s: pd.Series) -> float:
         """Kling-Gupta Efficiency - modified 2 (2021)."""
         if np.std(s) == 0 or np.std(p) == 0:
             return np.nan
@@ -392,69 +393,69 @@ def kge_mod2_wrapper(model: MetricsBasemodel) -> Callable:
 
         return 1.0 - euclidean_distance
 
-    return kling_gupta_efficiency_mod2
+    return kling_gupta_efficiency_mod2_inner
 
 
-def mae_wrapper(model: MetricsBasemodel) -> Callable:
+def mean_absolute_error(model: MetricsBasemodel) -> Callable:
     """Create the mean_absolute_error metric function."""
     logger.debug("Building the mean_absolute_error metric function")
 
-    def mean_absolute_error(p: pd.Series, s: pd.Series) -> float:
+    def mean_absolute_error_inner(p: pd.Series, s: pd.Series) -> float:
         """Mean absolute error."""
         p, s = _transform(p, s, model)
         return _mean_error(p, s)
 
-    return mean_absolute_error
+    return mean_absolute_error_inner
 
 
-def mse_wrapper(model: MetricsBasemodel) -> Callable:
+def mean_squared_error(model: MetricsBasemodel) -> Callable:
     """Create the mean_squared_error metric function."""
     logger.debug("Building the mean_squared_error metric function")
 
-    def mean_squared_error(p: pd.Series, s: pd.Series) -> float:
+    def mean_squared_error_inner(p: pd.Series, s: pd.Series) -> float:
         """Mean squared error."""
         p, s = _transform(p, s, model)
         return _mean_error(p, s, power=2.0)
 
-    return mean_squared_error
+    return mean_squared_error_inner
 
 
-def rmse_wrapper(model: MetricsBasemodel) -> Callable:
+def root_mean_squared_error(model: MetricsBasemodel) -> Callable:
     """Create the root_mean_squared_error metric function."""
     logger.debug("Building the root_mean_squared_error metric function")
 
-    def root_mean_squared_error(p: pd.Series, s: pd.Series) -> float:
+    def root_mean_squared_error_inner(p: pd.Series, s: pd.Series) -> float:
         """Root mean squared error."""
         p, s = _transform(p, s, model)
         return _mean_error(p, s, power=2.0, root=True)
 
-    return root_mean_squared_error
+    return root_mean_squared_error_inner
 
 
-def rmsdr_wrapper(model: MetricsBasemodel) -> Callable:
+def root_mean_standard_deviation_ratio(model: MetricsBasemodel) -> Callable:
     """Create the root_mean_standard_deviation_ratio metric function."""
     logger.debug(
         "Building the root_mean_standard_deviation_ratio metric function"
         )
 
-    def root_mean_standard_deviation_ratio(p: pd.Series,
-                                           s: pd.Series
-                                           ) -> float:
+    def root_mean_standard_deviation_ratio_inner(p: pd.Series,
+                                                 s: pd.Series
+                                                 ) -> float:
         """Root mean standard deviation ratio."""
         p, s = _transform(p, s, model)
         rmse = _root_mean_squared_error(p, s)
         obs_std_dev = np.std(p)
         return rmse / obs_std_dev
 
-    return root_mean_standard_deviation_ratio
+    return root_mean_standard_deviation_ratio_inner
 
 
 # Time-based Metrics
-def mvtd_wrapper(model: MetricsBasemodel) -> Callable:
+def max_value_timedelta(model: MetricsBasemodel) -> Callable:
     """Create the max_value_timedelta metric function."""
     logger.debug("Building the max_value_timedelta metric function")
 
-    def max_value_timedelta(
+    def max_value_timedelta_inner(
         p: pd.Series,
         s: pd.Series,
         value_time: pd.Series
@@ -468,4 +469,4 @@ def mvtd_wrapper(model: MetricsBasemodel) -> Callable:
 
         return td.total_seconds()
 
-    return max_value_timedelta
+    return max_value_timedelta_inner

--- a/src/teehr/metrics/probabilistic_funcs.py
+++ b/src/teehr/metrics/probabilistic_funcs.py
@@ -36,11 +36,11 @@ def _pivot_by_value_time(
     return {"primary": np.array(primary), "secondary": np.array(secondary)}
 
 
-def create_crps_func(model: MetricsBasemodel) -> Callable:
+def ensemble_crps(model: MetricsBasemodel) -> Callable:
     """Create the CRPS ensemble metric function."""
     logger.debug("Building the CRPS ensemble metric func.")
 
-    def ensemble_crps(
+    def ensemble_crps_inner(
         p: pd.Series,
         s: pd.Series,
         value_time: pd.Series,
@@ -85,4 +85,4 @@ def create_crps_func(model: MetricsBasemodel) -> Callable:
                 backend=model.backend
             )
 
-    return ensemble_crps
+    return ensemble_crps_inner

--- a/src/teehr/metrics/signature_funcs.py
+++ b/src/teehr/metrics/signature_funcs.py
@@ -66,11 +66,11 @@ def _transform(
         return p
 
 
-def mvt_wrapper(model: MetricsBasemodel) -> Callable:
+def max_value_time(model: MetricsBasemodel) -> Callable:
     """Create max_value_time metric function."""
     logger.debug("Building the max_value_time metric function")
 
-    def max_value_time(
+    def max_value_time_inner(
         p: pd.Series,
         value_time: pd.Series
     ) -> pd.Timestamp:
@@ -78,76 +78,76 @@ def mvt_wrapper(model: MetricsBasemodel) -> Callable:
         p, value_time = _transform(p, model, value_time)
         return value_time[p.idxmax()]
 
-    return max_value_time
+    return max_value_time_inner
 
 
-def variance_wrapper(model: MetricsBasemodel) -> Callable:
+def variance(model: MetricsBasemodel) -> Callable:
     """Create variance metric function."""
     logger.debug("Building the variance metric function")
 
-    def variance(p: pd.Series) -> float:
+    def variance_inner(p: pd.Series) -> float:
         """Variance."""
         p = _transform(p, model)
         return np.var(p)
 
-    return variance
+    return variance_inner
 
 
-def count_wrapper(model: MetricsBasemodel) -> Callable:
+def count(model: MetricsBasemodel) -> Callable:
     """Create count metric function."""
     logger.debug("Building the count metric function")
 
-    def count(p: pd.Series) -> float:
+    def count_inner(p: pd.Series) -> float:
         """Count."""
         p = _transform(p, model)
         return len(p)
 
-    return count
+    return count_inner
 
 
-def min_wrapper(model: MetricsBasemodel) -> Callable:
+def minimum(model: MetricsBasemodel) -> Callable:
     """Create minimum metric function."""
     logger.debug("Building the minimum metric function")
 
-    def minimum(p: pd.Series) -> float:
+    def minimum_inner(p: pd.Series) -> float:
         """Minimum."""
         p = _transform(p, model)
         return np.min(p)
 
-    return minimum
+    return minimum_inner
 
 
-def max_wrapper(model: MetricsBasemodel) -> Callable:
+def maximum(model: MetricsBasemodel) -> Callable:
     """Create maximum metric function."""
     logger.debug("Building the maximum metric function")
 
-    def maximum(p: pd.Series) -> float:
+    def maximum_inner(p: pd.Series) -> float:
         """Maximum."""
         p = _transform(p, model)
         return np.max(p)
 
-    return maximum
+    return maximum_inner
 
 
-def avg_wrapper(model: MetricsBasemodel) -> Callable:
+def average(model: MetricsBasemodel) -> Callable:
     """Create average metric function."""
     logger.debug("Building the average metric function")
 
-    def average(p: pd.Series) -> float:
+    def average_inner(p: pd.Series) -> float:
         """Average."""
         p = _transform(p, model)
         return np.mean(p)
 
-    return average
+    return average_inner
 
 
-def sum_wrapper(model: MetricsBasemodel) -> Callable:
+def sum(model: MetricsBasemodel) -> Callable:
     """Create sum metric function."""
     logger.debug("Building the sum metric function")
 
-    def sum(p: pd.Series) -> float:
+    def sum_inner(p: pd.Series) -> float:
         """Sum."""
         p = _transform(p, model)
         return np.sum(p)
 
-    return sum
+    return sum_inner

--- a/src/teehr/models/metrics/deterministic_models.py
+++ b/src/teehr/models/metrics/deterministic_models.py
@@ -36,7 +36,7 @@ class MeanError(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_error")
-    func: Callable = Field(metric_funcs.me_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.mean_error, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -67,7 +67,7 @@ class RelativeBias(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="relative_bias")
-    func: Callable = Field(metric_funcs.rb_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.relative_bias, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -98,7 +98,7 @@ class MultiplicativeBias(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="multiplicative_bias")
-    func: Callable = Field(metric_funcs.mb_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.multiplicative_bias, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -129,7 +129,7 @@ class MeanSquareError(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_square_error")
-    func: Callable = Field(metric_funcs.mse_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.mean_squared_error, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -160,7 +160,7 @@ class RootMeanSquareError(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="root_mean_square_error")
-    func: Callable = Field(metric_funcs.rmse_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.root_mean_squared_error, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -191,7 +191,7 @@ class MeanAbsoluteError(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_error")
-    func: Callable = Field(metric_funcs.mae_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.mean_absolute_error, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -222,7 +222,8 @@ class MeanAbsoluteRelativeError(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="mean_absolute_relative_error")
-    func: Callable = Field(metric_funcs.mare_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.mean_absolute_relative_error,
+                           frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -253,7 +254,7 @@ class PearsonCorrelation(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="pearson_correlation")
-    func: Callable = Field(metric_funcs.pc_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.pearson_correlation, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -284,7 +285,7 @@ class Rsquared(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="r_squared")
-    func: Callable = Field(metric_funcs.r_squared_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.r_squared, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -315,7 +316,7 @@ class NashSutcliffeEfficiency(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="nash_sutcliffe_efficiency")
-    func: Callable = Field(metric_funcs.nse_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.nash_sutcliffe_efficiency, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -348,7 +349,8 @@ class NormalizedNashSutcliffeEfficiency(DeterministicBasemodel):
     output_field_name: str = Field(
         default="nash_sutcliffe_efficiency_normalized"
     )
-    func: Callable = Field(metric_funcs.nse_norm_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.nash_sutcliffe_efficiency_normalized,
+                           frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -384,7 +386,7 @@ class KlingGuptaEfficiency(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency")
-    func: Callable = Field(metric_funcs.kge_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.kling_gupta_efficiency, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -423,7 +425,8 @@ class KlingGuptaEfficiencyMod1(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod1")
-    func: Callable = Field(metric_funcs.kge_mod1_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.kling_gupta_efficiency_mod1,
+                           frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -462,7 +465,8 @@ class KlingGuptaEfficiencyMod2(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="kling_gupta_efficiency_mod2")
-    func: Callable = Field(metric_funcs.kge_mod2_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.kling_gupta_efficiency_mod2,
+                           frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -495,7 +499,7 @@ class SpearmanCorrelation(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="spearman_correlation")
-    func: Callable = Field(metric_funcs.spearman_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.spearman_correlation, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -524,7 +528,7 @@ class MaxValueDelta(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_delta")
-    func: Callable = Field(metric_funcs.mvd_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.max_value_delta, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -554,7 +558,7 @@ class MaxValueTimeDelta(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time_delta")
-    func: Callable = Field(metric_funcs.mvtd_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.max_value_timedelta, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
@@ -585,7 +589,7 @@ class AnnualPeakRelativeBias(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="annual_peak_flow_bias")
-    func: Callable = Field(metric_funcs.aprb_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.annual_peak_relative_bias, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
     )
@@ -616,7 +620,8 @@ class RootMeanStandardDeviationRatio(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="root_mean_standard_deviation_ratio")  # noqa: E501
-    func: Callable = Field(metric_funcs.rmsdr_wrapper, frozen=True)
+    func: Callable = Field(metric_funcs.root_mean_standard_deviation_ratio,
+                           frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value"]
     )
@@ -628,8 +633,8 @@ class DeterministicMetrics:
 
     Notes
     -----
-    Deterministic metrics compare two timeseries, typically primary ("observed")
-    vs. secondary ("modeled") values. Available metrics include:
+    Deterministic metrics compare two timeseries, typically primary
+    ("observed") vs. secondary ("modeled") values. Available metrics include:
 
     - AnnualPeakRelativeBias
     - KlingGuptaEfficiency

--- a/src/teehr/models/metrics/probabilistic_models.py
+++ b/src/teehr/models/metrics/probabilistic_models.py
@@ -38,7 +38,7 @@ class CRPS(ProbabilisticBasemodel):
     transform: TransformEnum = Field(default=None)
     backend: str = Field(default="numba")
     output_field_name: str = Field(default="mean_crps_ensemble")
-    func: Callable = Field(probabilistic_funcs.create_crps_func, frozen=True)
+    func: Callable = Field(probabilistic_funcs.ensemble_crps, frozen=True)
     summary_func: Union[Callable, None] = Field(default=None)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "secondary_value", "value_time"]
@@ -52,7 +52,8 @@ class ProbabilisticMetrics:
     Notes
     -----
     Probabilistic metrics compare a value against a distribution of predicted
-    values, such as ensemble forecasts. Available probabilistic metrics include:
+    values, such as ensemble forecasts. Available probabilistic metrics
+    include:
 
     - CRPS (Continuous Ranked Probability Score)
     """

--- a/src/teehr/models/metrics/signature_models.py
+++ b/src/teehr/models/metrics/signature_models.py
@@ -34,7 +34,7 @@ class Count(DeterministicBasemodel):
 
     output_field_name: str = Field(default="count")
     transform: TransformEnum = Field(default=None)
-    func: Callable = Field(default=sig_funcs.count_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.count, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
@@ -63,7 +63,7 @@ class Minimum(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="minimum")
-    func: Callable = Field(default=sig_funcs.min_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.minimum, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
@@ -92,7 +92,7 @@ class Maximum(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="maximum")
-    func: Callable = Field(default=sig_funcs.max_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.maximum, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
@@ -121,7 +121,7 @@ class Average(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="average")
-    func: Callable = Field(default=sig_funcs.avg_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.average, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
@@ -150,7 +150,7 @@ class Sum(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="sum")
-    func: Callable = Field(default=sig_funcs.sum_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.sum, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
@@ -180,7 +180,7 @@ class Variance(DeterministicBasemodel):
     bootstrap: BootstrapBasemodel = Field(default=None)
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="variance")
-    func: Callable = Field(default=sig_funcs.variance_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.variance, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value"]
     )
@@ -209,7 +209,7 @@ class MaxValueTime(DeterministicBasemodel):
 
     transform: TransformEnum = Field(default=None)
     output_field_name: str = Field(default="max_value_time")
-    func: Callable = Field(default=sig_funcs.mvt_wrapper, frozen=True)
+    func: Callable = Field(default=sig_funcs.max_value_time, frozen=True)
     input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
         default=["primary_value", "value_time"]
     )


### PR DESCRIPTION
Given all my attempts to create a uniform metrics decorator have been thwarted by the pandas_udf portion of the metrics query, I thought we could at least clean up the API reference here...

- Updates the metric wrappers to expose the unabbreviated metric function names to the API (e.g. `aprb_wrapper` --> `annual_peak_relative_bias`)
- Renames the wrapped function (e.g. `annual_peak_relative_bias` --> `annual_peak_relative_bias_inner`)
- Docstrings for most of the 'inner functions' (the original metric functions) were not super descriptive. Open to adding detail to the docstring exposed to the API but not sure how that should look given the mesh of metric table model/wrapped function/inner function. Since users parameterize the metric function by first defining an instance of the table model (which has really detailed docstring), I don't see a lot of reason to go overboard on the docstrings here. 
  - I just though updating the actual metric func names in the API provide a better inventory of what is implemented than the 'XXX_wrapper' nomenclature that is currently there. 