### PR TITLE
adds option to add only specified location attributes to jts

### DIFF
--- a/tests/test_create_joined_timeseries.py
+++ b/tests/test_create_joined_timeseries.py
@@ -122,8 +122,11 @@ def test_create_joined_timeseries(tmpdir):
         pattern="test_attr_*.parquet",
     )
 
-    # Create the joined timeseries
-    ev.joined_timeseries.create(add_attrs=True, execute_scripts=True)
+    # Create the joined timeseries with only specified attributes
+    attr_list = ['drainage_area', 'ecoregion']
+    ev.joined_timeseries.create(add_attrs=True,
+                                execute_scripts=True,
+                                attr_list=attr_list)
 
     columns = ev.joined_timeseries.to_sdf().columns
     expected_columns = [
@@ -136,7 +139,6 @@ def test_create_joined_timeseries(tmpdir):
         'unit_name',
         'drainage_area',
         'ecoregion',
-        'year_2_discharge',
         'month',
         'year',
         'water_year',


### PR DESCRIPTION
Updates the `create()` method for the joined timeseries to allow for a list of attributes. Allows user to subset which location attributes are added to their joined timeseries instead of adding all by default.