### PR TITLE
348 add past teehr resources to docs

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -10,7 +10,7 @@ TEEHR Documentation
 
 TEEHR (pronounced "tier") is a Python tool set for loading, storing, processing and visualizing hydrologic data, particularly National Water Model data, for the purpose of exploring and evaluating the datasets to assess their skill and performance.
 
-.. grid:: 1 2 2 2
+.. grid:: 1 2 3 3
     :gutter: 4
     :padding: 2 2 0 0
     :class-container: sd-text-center
@@ -89,6 +89,25 @@ TEEHR (pronounced "tier") is a Python tool set for loading, storing, processing 
 
             To the development guide
 
+    .. grid-item-card::  Legacy TEEHR Content
+        :img-top: _static/index_user_guide.svg
+        :class-card: intro-card
+        :shadow: md
+
+        The legacy TEEHR content is no longer maintained, but
+        it is still available for reference. It contains various materials
+        created throughout the development process.
+
+        +++
+
+        .. button-ref:: legacy_content
+            :ref-type: ref
+            :click-parent:
+            :color: secondary
+            :expand:
+
+            To the legacy content
+
 
 .. toctree::
    :hidden:
@@ -100,3 +119,4 @@ TEEHR (pronounced "tier") is a Python tool set for loading, storing, processing 
    development/index
    changelog/index
    api/index
+   legacy_content/index

--- a/docs/sphinx/legacy_content/index.rst
+++ b/docs/sphinx/legacy_content/index.rst
@@ -1,0 +1,53 @@
+.. _legacy_content:
+
+====================
+Legacy TEEHR Content
+====================
+
+The legacy TEEHR content is no longer maintained, but it is still available for reference. It contains various
+materials created throughout the development process including notebooks, tutorials, workshop materials, and more.
+
+These materials are intended for advanced TEEHR users. They are not actively updated and may not reflect the latest
+features or best practices in TEEHR. However, they can still provide valuable insights into the development and
+usage of TEEHR.
+
+.. note::
+   The legacy content is provided for historical reference and educational purposes.
+   It may not be compatible with the latest version of TEEHR or its dependencies.
+   The content is provided "as is" without any guarantees of functionality or support.
+
+* `TEEHR Hub <https://github.com/RTIInternational/teehr-hub>`__
+
+  * TEEHR Hub is repository containing a collection of TEEHR-related resources for creating a cloud-based AWS environment for TEEHR development and deployment.
+
+* `CIROH DevCon 2025 Workshop <https://github.com/RTIInternational/teehr-devcon25-workshop>`__
+
+  * A repository containing materials for the CIROH DevCon 2025 workshop, including notebooks and other examples.
+
+* `NGIAB TEEHR <https://github.com/RTIInternational/ngiab-teehr>`__
+
+  * A repository containing materials for coupling Nextgen-in-a-Box (NGIAB) with TEEHR.
+
+* `TEEHR Evaluations <https://github.com/RTIInternational/teehr-evaluations>`__
+
+  * A collection of TEEHR evaluations containing useful examples and workflows for evaluating hydrologic data using TEEHR.
+
+* `TEEHR Spark Iceberg <https://github.com/RTIInternational/teehr-spark-iceberg>`__
+
+  * A repository to hold code related to testing Spark and Iceberg integration with TEEHR.
+
+* `CIROH DevCon 2024 Workshop <https://github.com/RTIInternational/teehr-devcon24-workshop>`__
+
+  * A repository containing materials for the CIROH DevCon 2024 workshop, including notebooks and other examples.
+
+* `CIROH DevCon 2024 Poster <https://github.com/RTIInternational/teehr-may-2024-devcon-poster>`__
+
+  * A repository containing materials supporting the benchmark analysis presented in the 2024 CIROH DevCon poster.
+
+* `TEEHR Post Event <https://github.com/RTIInternational/teehr-post-event>`__
+
+  * A collection of modules and notebooks to facilitate exploratory evaluation of hydrologic forecast performance of flood events using TEEHR.
+
+* `CIROH DevCon 2023 Workshop <https://github.com/RTIInternational/teehr-may-2023-workshop>`__
+
+  * A repository containing materials for the CIROH DevCon 2023 workshop, including notebooks and other examples.


### PR DESCRIPTION
- Creates a new landing page tile containing links to legacy TEEHR content. Has a clear disclaimer about usage and suggests only advanced users should proceed. 
  - Made a new landing page tile as I wanted to silo these materials away from the content that pertains to ongoing development. 