### PR TITLE
487 write teehr version to v05 evaluation

### DIFF
--- a/src/teehr/evaluation/evaluation.py
+++ b/src/teehr/evaluation/evaluation.py
@@ -27,6 +27,10 @@ from teehr.evaluation.fetch import Fetch
 from teehr.evaluation.metrics import Metrics
 import pandas as pd
 from teehr.visualization.dataframe_accessor import TEEHRDataFrameAccessor # noqa
+import re
+import teehr
+import s3fs
+from fsspec.implementations.local import LocalFileSystem
 
 
 logger = logging.getLogger(__name__)
@@ -80,6 +84,10 @@ class Evaluation:
             else:
                 logger.error(f"Directory {self.dir_path} does not exist.")
                 raise NotADirectoryError
+
+        # Check version of Evaluation
+        if create_dir is False:
+            self.check_evaluation_version()
 
         # Create a local Spark Session if one is not provided.
         if not self.spark:
@@ -347,3 +355,56 @@ class Evaluation:
             self.joined_timeseries.to_sdf().createOrReplaceTempView("joined_timeseries")
 
         return self.spark.sql(query)
+
+    def check_evaluation_version(self):
+        """Check the version of the TEEHR Evaluation."""
+        if self.is_s3:
+            fs = s3fs.S3FileSystem(anon=True)
+            version_file = self.dir_path.path + "/" + "version"
+        else:
+            fs = LocalFileSystem()
+            version_file = Path(self.dir_path, "version")
+        if not fs.exists(version_file):
+            logger.error(f"Version file not found in {self.dir_path}.")
+            if self.is_s3:
+                err_msg = (
+                    f"Please create a version file in {self.dir_path}."
+                )
+                logger.error(err_msg)
+                raise Exception(err_msg)
+            else:
+                # TODO: Change this to raise an error in v0.6.
+                version = teehr.__version__
+                with fs.open(version_file, "w") as f:
+                    f.write(version)
+                logger.info(
+                    f"Created version file in {self.dir_path}."
+                    " In the future this will raise an error."
+                )
+        else:
+            with fs.open(version_file) as f:
+                version_txt = str(f.read().strip())
+            match = re.findall(r'(\d+\.\d+\.\d+)', version_txt)  # Assumes semantic versioning
+            if len(match) != 1:
+                err_msg = f"Invalid version format in {self.dir_path}: {version_txt}"
+                logger.error(err_msg)
+                raise ValueError(err_msg)
+            else:
+                version = match[0]
+        # TODO: Uncomment this in v0.6
+        # if version < "0.6.0":
+        #     err_msg = (
+        #         f"Evaluation version {version} in {self.dir_path} is less than 0.6."
+        #         " Please run the migration to upgrade to the latest version."
+        #     )
+        #     logger.error(err_msg)
+        #     raise ValueError(err_msg)
+        # else:
+        #     # Update the version to the latest
+        #     pass
+        logger.info(
+            f"Found evaluation version {version} in {self.dir_path}."
+            " Future versions v0.6 and greater will require a conversion"
+            " to a new format."
+        )
+        return version

--- a/src/teehr/loading/s3/clone_from_s3.py
+++ b/src/teehr/loading/s3/clone_from_s3.py
@@ -204,3 +204,11 @@ def clone_from_s3(
     with fsspec.open(source, 'r', anon=True) as file:
         with open(dest, 'w') as f:
             f.write(file.read())
+
+    # TEMP: Also copy version file to the evaluation directory
+    source = f"{url}/version"
+    dest = f"{ev.dir_path}/version"
+    logger.debug(f"Copying from {source}/ to {dest}")
+    with fsspec.open(source, 'r', anon=True) as file:
+        with open(dest, 'w') as f:
+            f.write(file.read())

--- a/tests/test_clone_from_s3.py
+++ b/tests/test_clone_from_s3.py
@@ -29,7 +29,7 @@ def test_clone_example_from_s3(tmpdir):
     assert ev.units.to_sdf().count() == 4
     assert ev.variables.to_sdf().count() == 3
     assert ev.attributes.to_sdf().count() == 26
-    assert ev.configurations.to_sdf().count() == 161
+    assert ev.configurations.to_sdf().count() == 2
     assert ev.locations.to_sdf().count() == 2
     assert ev.location_attributes.to_sdf().count() == 50
     assert ev.location_crosswalks.to_sdf().count() == 2
@@ -69,7 +69,7 @@ def test_clone_and_subset_example_from_s3(tmpdir):
     assert ev.units.to_sdf().count() == 4
     assert ev.variables.to_sdf().count() == 3
     assert ev.attributes.to_sdf().count() == 26
-    assert ev.configurations.to_sdf().count() == 161
+    assert ev.configurations.to_sdf().count() == 2
     assert ev.locations.to_sdf().count() == 1
     assert ev.location_attributes.to_sdf().count() == 25
     assert ev.location_crosswalks.to_sdf().count() == 1

--- a/tests/test_read_from_s3.py
+++ b/tests/test_read_from_s3.py
@@ -13,7 +13,7 @@ def test_read_from_s3():
     assert var_cnt == 3
 
     conf_cnt = ev.configurations.to_sdf().count()
-    assert conf_cnt == 161
+    assert conf_cnt == 2
 
     attrs_cnt = ev.attributes.to_sdf().count()
     assert attrs_cnt == 26


### PR DESCRIPTION
- Adds new method `check_evaluation_version` on Evaluation
- Gets called during Evaluation initialization
- If `ev.dir_path` is a local path:
    - If version file does not exist, write one with current TEEHR version to root of ev dir
    - If it does exist, read it
- If an S3 path:
    - If version file does not exist, raise error
    - If it does, read it
- Check if version < 0.6. After v0.6, raise an error if so, or update if > 0.6. Currently just logs a message.
- Added version file to S3 evaluations
- Updated `clone_from_s3` to also copy version file