### PR TITLE
421 usgs fetching can return multiple data types

### DIFF
--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -179,6 +179,14 @@ class Fetch:
         drop_duplicates : bool
             Whether to drop duplicates in the data. Default is True.
 
+        .. note::
+
+           Only codes '00060' (Discharge, cubic feet per second, service='iv')
+           and '00060_Mean' (Discharge, Mean cubic feet per second, service='dv')
+           are supported. If data is returned from NWIS with a different field name,
+           such as '00060_total spillway releases' in the case of a reservoir,
+           the function will return None and log an error message.
+
 
         .. note::
 

--- a/tests/test_usgs_fetching_chunkby.py
+++ b/tests/test_usgs_fetching_chunkby.py
@@ -10,8 +10,24 @@ from teehr.fetching.usgs.usgs import usgs_to_parquet
 
 def test_chunkby_location_id(tmpdir):
     """Test chunkby location id."""
+    # See gage 08025360 from April 1-9
+    # usgs_to_parquet(
+    #     sites=[
+    #         "08025360",
+    #         "02449838"
+    #     ],
+    #     start_date=datetime(2023, 4, 1),
+    #     end_date=datetime(2023, 4, 9),
+    #     output_parquet_dir=Path(tmpdir),
+    #     chunk_by="location_id",
+    #     overwrite_output=True
+    # )
+
+    # pass
+
     usgs_to_parquet(
         sites=[
+            "08025360",
             "02449838",
             "02450825"
         ],

--- a/tests/test_usgs_fetching_chunkby.py
+++ b/tests/test_usgs_fetching_chunkby.py
@@ -10,24 +10,9 @@ from teehr.fetching.usgs.usgs import usgs_to_parquet
 
 def test_chunkby_location_id(tmpdir):
     """Test chunkby location id."""
-    # See gage 08025360 from April 1-9
-    # usgs_to_parquet(
-    #     sites=[
-    #         "08025360",
-    #         "02449838"
-    #     ],
-    #     start_date=datetime(2023, 4, 1),
-    #     end_date=datetime(2023, 4, 9),
-    #     output_parquet_dir=Path(tmpdir),
-    #     chunk_by="location_id",
-    #     overwrite_output=True
-    # )
-
-    # pass
-
     usgs_to_parquet(
         sites=[
-            "08025360",
+            "08025360",  # Reservoir will be skipped
             "02449838",
             "02450825"
         ],


### PR DESCRIPTION
After investigation it seems there is no programmatic way to tell, ahead of time, what type of discharge data a site contains. 

We request discharge data using parameter `00060`.  In some cases this may return more than one value (which is the case for 08025360, a reservoir).
<img width="1392" height="234" alt="image" src="https://github.com/user-attachments/assets/85c976b8-5896-49d8-be0d-76410cfef54a" />

The USGS python `dataretrieval` tool, which we use here, typically returns a single column of discharge data named `00060` (or `00060_Mean` for daily mean).  In the of this reservoir, multiple columns are returned 
<img width="2723" height="242" alt="image" src="https://github.com/user-attachments/assets/7a072734-2229-4f39-94ae-957543832cc4" />

This PR updates the error handling and logging in the USGS fetching to ignore data other than `00060` or `00060_Mean`.

Basically the end result is that reservoir/spillway outflows (and any other types) are ignored in the USGS fetching method. 

Let me know if you want to discuss