### PR TITLE
501 investigate intervaltype errors

### DIFF
--- a/src/teehr/models/calculated_fields/row_level.py
+++ b/src/teehr/models/calculated_fields/row_level.py
@@ -214,7 +214,7 @@ class Seasons(CalculatedFieldABC, CalculatedFieldBaseModel):
 
 
 class ForecastLeadTime(CalculatedFieldABC, CalculatedFieldBaseModel):
-    """Adds the forecast lead time from a timestamp column.
+    """Adds the forecast lead time in seconds from a timestamp column.
 
     Properties
     ----------

--- a/src/teehr/models/calculated_fields/row_level.py
+++ b/src/teehr/models/calculated_fields/row_level.py
@@ -242,12 +242,12 @@ class ForecastLeadTime(CalculatedFieldABC, CalculatedFieldBaseModel):
 
     def apply_to(self, sdf: ps.DataFrame) -> ps.DataFrame:
         """Apply the calculated field to the Spark DataFrame."""
-        @pandas_udf(returnType=T.DoubleType())
+        @pandas_udf(returnType=T.LongType())
         def func(value_time: pd.Series,
                  reference_time: pd.Series
                  ) -> pd.Series:
             difference = value_time - reference_time
-            return difference.dt.total_seconds() / 3600
+            return difference.dt.total_seconds()
 
         sdf = sdf.withColumn(
             self.output_field_name,

--- a/src/teehr/models/calculated_fields/row_level.py
+++ b/src/teehr/models/calculated_fields/row_level.py
@@ -242,12 +242,12 @@ class ForecastLeadTime(CalculatedFieldABC, CalculatedFieldBaseModel):
 
     def apply_to(self, sdf: ps.DataFrame) -> ps.DataFrame:
         """Apply the calculated field to the Spark DataFrame."""
-        @pandas_udf(returnType=T.DayTimeIntervalType())
+        @pandas_udf(returnType=T.DoubleType())
         def func(value_time: pd.Series,
                  reference_time: pd.Series
                  ) -> pd.Series:
             difference = value_time - reference_time
-            return difference
+            return difference.dt.total_seconds() / 3600
 
         sdf = sdf.withColumn(
             self.output_field_name,

--- a/tests/test_add_udfs.py
+++ b/tests/test_add_udfs.py
@@ -80,9 +80,9 @@ def test_add_row_udfs(tmpdir):
         assert row["season"] in ["winter", "spring", "summer", "fall"]
 
     assert "forecast_lead_time" in cols
-    assert sdf.schema["forecast_lead_time"].dataType == T.DoubleType()
+    assert sdf.schema["forecast_lead_time"].dataType == T.LongType()
     row = check_sdf.collect()[1]
-    expected_val = (row["value_time"] - row["reference_time"]).total_seconds() / 3600.0
+    expected_val = (row["value_time"] - row["reference_time"]).total_seconds()
     test_val = row["forecast_lead_time"]
     assert expected_val == test_val
 

--- a/tests/test_add_udfs.py
+++ b/tests/test_add_udfs.py
@@ -82,7 +82,7 @@ def test_add_row_udfs(tmpdir):
     assert "forecast_lead_time" in cols
     assert sdf.schema["forecast_lead_time"].dataType == T.DoubleType()
     row = check_sdf.collect()[1]
-    expected_val = row["value_time"] - row["reference_time"]
+    expected_val = (row["value_time"] - row["reference_time"]).total_seconds() / 3600.0
     test_val = row["forecast_lead_time"]
     assert expected_val == test_val
 

--- a/tests/test_add_udfs.py
+++ b/tests/test_add_udfs.py
@@ -80,7 +80,7 @@ def test_add_row_udfs(tmpdir):
         assert row["season"] in ["winter", "spring", "summer", "fall"]
 
     assert "forecast_lead_time" in cols
-    assert sdf.schema["forecast_lead_time"].dataType == T.DayTimeIntervalType()
+    assert sdf.schema["forecast_lead_time"].dataType == T.DoubleType()
     row = check_sdf.collect()[1]
     expected_val = row["value_time"] - row["reference_time"]
     test_val = row["forecast_lead_time"]


### PR DESCRIPTION
- Removed the `intervalType` and instead had `forecast_lead_time` return a float representation of hours. Could easily be updated to accept different float/integer time representations (days, seconds, etc.) if we wanted to go a different route. 
- Tested filters, chained metric queries, etc. and all seem to work fine with the new datatype
- Seems to resolve to miscommunication between pandas dataframe/pyspark dataframe conversion on test ensemble data as well as example HEFS data
- Updated tests  