### PR TITLE
539 expose kge variance ratio component as metric

### DIFF
--- a/src/teehr/__init__.py
+++ b/src/teehr/__init__.py
@@ -1,7 +1,7 @@
 """Initialize the TEEHR package."""
 import warnings
 
-__version__ = "0.5.1dev3"
+__version__ = "0.5.1dev4"
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", UserWarning)

--- a/src/teehr/metrics/deterministic_funcs.py
+++ b/src/teehr/metrics/deterministic_funcs.py
@@ -177,6 +177,21 @@ def pearson_correlation(model: MetricsBasemodel) -> Callable:
     return pearson_correlation_inner
 
 
+def variability_ratio(model: MetricsBasemodel) -> Callable:
+    """Create the Variability Ratio metric function.
+
+    :math:`VR=\\frac{\\sigma_{sec}}{\\sigma_{prim}}`
+    """ # noqa
+    logger.debug("Building the variability_ratio metric function")
+
+    def variability_ratio_inner(p: pd.Series, s: pd.Series) -> float:
+        """Variability Ratio."""
+        p, s = _transform(p, s, model)
+        return np.std(s)/np.std(p)
+
+    return variability_ratio_inner
+
+
 def r_squared(model: MetricsBasemodel) -> Callable:
     """Create the R-squared metric function.
 

--- a/src/teehr/models/metrics/deterministic_models.py
+++ b/src/teehr/models/metrics/deterministic_models.py
@@ -261,6 +261,36 @@ class PearsonCorrelation(DeterministicBasemodel):
     attrs: Dict = Field(default=tma.PEARSON_ATTRS, frozen=True)
 
 
+class VariabilityRatio(DeterministicBasemodel):
+    """Variability Ratio.
+
+    Parameters
+    ----------
+    bootstrap : DeterministicBasemodel
+        The bootstrap model, by default None.
+    transform : TransformEnum
+        The transformation to apply to the data, by default None.
+    output_field_name : str
+        The output field name, by default "variability_ratio".
+    func : Callable
+        The function to apply to the data, by default
+        :func:`deterministic_funcs.variability_ratio`.
+    input_field_names : Union[str, StrEnum, List[Union[str, StrEnum]]]
+        The input field names, by default ["primary_value", "secondary_value"].
+    attrs : Dict
+        The static attributes for the metric.
+    """
+
+    bootstrap: BootstrapBasemodel = Field(default=None)
+    transform: TransformEnum = Field(default=None)
+    output_field_name: str = Field(default="variability_ratio")
+    func: Callable = Field(metric_funcs.variability_ratio, frozen=True)
+    input_field_names: Union[str, StrEnum, List[Union[str, StrEnum]]] = Field(
+        default=["primary_value", "secondary_value"]
+    )
+    attrs: Dict = Field(default=tma.VR_ATTRS, frozen=True)
+
+
 class Rsquared(DeterministicBasemodel):
     """Coefficient of Determination.
 
@@ -669,6 +699,7 @@ class DeterministicMetrics:
     MeanSquareError = MeanSquareError
     MultiplicativeBias = MultiplicativeBias
     PearsonCorrelation = PearsonCorrelation
+    VariabilityRatio = VariabilityRatio
     NashSutcliffeEfficiency = NashSutcliffeEfficiency
     NormalizedNashSutcliffeEfficiency = NormalizedNashSutcliffeEfficiency
     RelativeBias = RelativeBias

--- a/src/teehr/models/metrics/metric_attributes.py
+++ b/src/teehr/models/metrics/metric_attributes.py
@@ -66,6 +66,14 @@ PEARSON_ATTRS = {
     "optimal_value": 1.0,
 }
 
+VR_ATTRS = {
+    "short_name": "VR",
+    "display_name": "Variance Ratio",
+    "category": mc.Deterministic,
+    "value_range": [None, None],
+    "optimal_value": 1.0,
+}
+
 R2_ATTRS = {
     "short_name": "r2",
     "display_name": "Coefficient of Determination",

--- a/src/teehr/models/metrics/metric_attributes.py
+++ b/src/teehr/models/metrics/metric_attributes.py
@@ -70,7 +70,7 @@ VR_ATTRS = {
     "short_name": "VR",
     "display_name": "Variance Ratio",
     "category": mc.Deterministic,
-    "value_range": [None, None],
+    "value_range": [0.0, None],
     "optimal_value": 1.0,
 }
 

--- a/tests/query/test_get_metrics_query.py
+++ b/tests/query/test_get_metrics_query.py
@@ -61,7 +61,7 @@ def test_executing_deterministic_metrics(tmpdir):
 
     assert isinstance(metrics_df, pd.DataFrame)
     assert metrics_df.index.size == 3
-    assert metrics_df.columns.size == 20
+    assert metrics_df.columns.size == 21
 
 
 def test_executing_signature_metrics(tmpdir):


### PR DESCRIPTION
- Adds variance ratio to the deterministic metrics
- Should allow users to obtain all the intermediary calcs for KGE directly via their respective metric models