### PR TITLE
corrects error with unpack_results argument

### DIFF
--- a/src/teehr/models/metrics/basemodels.py
+++ b/src/teehr/models/metrics/basemodels.py
@@ -1,5 +1,5 @@
 """Enums and Basemodels for metric classes."""
-from typing import Union, Callable
+from typing import Union, Callable, List
 
 from teehr.models.str_enum import StrEnum
 from teehr.querying.utils import unpack_sdf_dict_columns
@@ -38,8 +38,19 @@ class ProbabilisticBasemodel(MetricsBasemodel):
         return values
 
 
-class BootstrapBasemodel(MetricsBasemodel):
+class BootstrapBasemodel(PydanticBaseModel):
     """Bootstrap Basemodel configuration."""
+
+    return_type: Union[str, T.ArrayType, T.MapType] = Field(default=None)
+    reps: int = 1000
+    seed: Union[int, None] = None
+    quantiles: Union[List[float], None] = None
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+        extra='forbid'  # raise an error if extra fields are passed
+    )
 
     @model_validator(mode="before")
     def update_return_type(cls, values):

--- a/src/teehr/models/metrics/bootstrap_models.py
+++ b/src/teehr/models/metrics/bootstrap_models.py
@@ -56,9 +56,6 @@ class Gumboot(BootstrapBasemodel):
 
     """
 
-    reps: int = 1000
-    seed: Union[int, None] = None
-    quantiles: Union[List[float], None] = None
     boot_year_file: Union[str, Path, None] = None
     water_year_month: int = 10
     name: str = Field(default="Gumboot")
@@ -92,11 +89,8 @@ class CircularBlock(BootstrapBasemodel):
         The wrapper to generate the bootstrapping function.
     """
 
-    seed: Union[int, None] = None
     random_state: Union[RandomState, None] = None
-    reps: int = 1000
     block_size: int = 365
-    quantiles: Union[List[float], None] = None
     name: str = Field(default="CircularBlock")
     include_value_time: bool = Field(False, frozen=True)
     func: Callable = Field(
@@ -131,11 +125,8 @@ class Stationary(BootstrapBasemodel):
         The wrapper to generate the bootstrapping function.
     """
 
-    seed: Union[int, None] = None
     random_state: Union[RandomState, None] = None
-    reps: int = 1000
     block_size: int = 365
-    quantiles: Union[List[float], None] = None
     name: str = Field(default="Stationary")
     include_value_time: bool = Field(False, frozen=True)
     func: Callable = Field(

--- a/src/teehr/querying/metric_format.py
+++ b/src/teehr/querying/metric_format.py
@@ -36,12 +36,6 @@ def apply_aggregation_metrics(
                 f"Applying metric: {alias} with {model.bootstrap.name}"
                 " bootstrapping"
             )
-            if model.bootstrap.unpack_results and not model.unpack_results:
-                model.unpack_results = True
-                logger.debug(
-                    f"Setting unpack_results to True on metric {alias} "
-                    "to enable unpacking of bootstrap results."
-                )
             func_pd = pandas_udf(
                 model.bootstrap.func(model),
                 model.bootstrap.return_type


### PR DESCRIPTION
I was able to get the unpack_results functionality to work as intended (prior to this update) like: 

```
# Define a bootstrapper with custom parameters.
boot = teehr.Bootstrappers.Gumboot(
    reps=500,
    quantiles=[0.05, 0.5, 0.95],
)

metrics_sdf = ev.metrics.query(
    group_by=[
        "primary_location_id",
        "configuration_name"
    ],
    include_metrics=[
        teehr.DeterministicMetrics.RelativeBias(
            bootstrap=boot,
            unpack_results=True # defined here instead
        )
    ]
).to_sdf()
```

When applying the bootstrapper in `teehr.querying.metric_format.apply_aggregation_metrics()`, we were not checking if the `bootstrap.unpack_results` attribute was set or not. The unpacking hinged solely on if you defined the argument when instantiating the metric function you are bootstrapping. 

I updated  `teehr.querying.metric_format.apply_aggregation_metrics()` to check the bootstrap attributes for `unpack_results`.  This allows you to define the `unpack_results` arg when instantiating the bootstrap and/or when defining the metric you apply the bootstrap to (i.e. the code Matt attached in the issue works in addition to the above).