### PR TITLE
591 possible bug in foreign key enforcement using load dataframe

### DIFF
--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -257,6 +257,7 @@ class Fetch:
             sites=sites,
             start_date=start_date,
             end_date=end_date,
+            service=service,
             output_parquet_dir=Path(
                 self.usgs_cache_dir,
                 USGS_CONFIGURATION_NAME,


### PR DESCRIPTION
Fixes a bug in `load_dataframe()` to ensure that the order of the fields in the dataframe is that same as the order of fields in the table schema

Also added the `service` arg to `Fetch.usgs_streamflow()` which was missing for some reason