### PR TITLE
pin netcdf4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7664,4 +7664,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "5180f0993b7e2ed8c62b40350c321864d942f021be3ed8165ec8d8098926702d"
+content-hash = "5186fbabd2b0adcb2a8902f4f7aef73435c1cfb72d606e4ebec49f7dde150d1c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dataretrieval = ">=1.0.9,<2"
 numba = ">=0.60.0,<1"
 arch = ">=7.0.0,<8"
 pandera = {extras = ["pyspark"], version = ">=0.20.4,<1"}
-netcdf4 = ">=1.6.5,<2"
+netcdf4 = "1.7.2"
 scoringrules = ">=0.7.1,<1"
 pyiceberg = {extras = ["sql-lite"], version = "^0.10.0"}
 lxml = ">=5.4.0,<6"


### PR DESCRIPTION
- Pinning netcdf4 to version 1.7.2 fixes an issue with parsing netcdf files with xarray and kerchunk, and should fix the failing NWM operational ingests in TEEHR-Hub.
