### PR TITLE
744 fix filename issue in nwm fetching using ciroh kerchunk files

### DIFF
--- a/src/teehr/evaluation/fetch.py
+++ b/src/teehr/evaluation/fetch.py
@@ -725,7 +725,7 @@ class Fetch:
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         ingest_days: Optional[int] = None,
         data_source: Optional[SupportedNWMDataSourcesEnum] = "GCS",
-        kerchunk_method: Optional[SupportedKerchunkMethod] = "local",
+        kerchunk_method: Optional[SupportedKerchunkMethod] = "auto",
         prioritize_analysis_value_time: Optional[bool] = False,
         t_minus_hours: Optional[List[int]] = None,
         process_by_z_hour: Optional[bool] = True,
@@ -788,11 +788,11 @@ class Fetch:
             Currently only "GCS" is implemented.
         kerchunk_method : Optional[SupportedKerchunkMethod]
             When data_source = "GCS", specifies the preference in creating Kerchunk
-            reference json files. "local" (default) will create new json files from
+            reference json files. "local" - create new json files from
             netcdf files in GCS and save to a local directory if they do not already
             exist locally, in which case the creation is skipped. "remote" - read the
             CIROH pre-generated jsons from s3, ignoring any that are unavailable.
-            "auto" - read the CIROH pre-generated jsons from s3, and create any that
+            "auto" (default) - read the CIROH pre-generated jsons from s3, and create any that
             are unavailable, storing locally.
         prioritize_analysis_value_time : Optional[bool]
             A boolean flag that determines the method of fetching analysis-assimilation
@@ -1005,7 +1005,7 @@ class Fetch:
         calculate_zonal_weights: bool = False,
         location_id_prefix: Optional[str] = None,
         data_source: Optional[SupportedNWMDataSourcesEnum] = "GCS",
-        kerchunk_method: Optional[SupportedKerchunkMethod] = "local",
+        kerchunk_method: Optional[SupportedKerchunkMethod] = "auto",
         prioritize_analysis_value_time: Optional[bool] = False,
         t_minus_hours: Optional[List[int]] = None,
         ignore_missing_file: Optional[bool] = True,
@@ -1081,11 +1081,11 @@ class Fetch:
             Currently only "GCS" is implemented.
         kerchunk_method : Optional[SupportedKerchunkMethod]
             When data_source = "GCS", specifies the preference in creating Kerchunk
-            reference json files. "local" (default) will create new json files from
+            reference json files. "local" - create new json files from
             netcdf files in GCS and save to a local directory if they do not already
             exist locally, in which case the creation is skipped. "remote" - read the
             CIROH pre-generated jsons from s3, ignoring any that are unavailable.
-            "auto" - read the CIROH pre-generated jsons from s3, and create any that
+            "auto" (default) - read the CIROH pre-generated jsons from s3, and create any that
             are unavailable, storing locally.
         prioritize_analysis_value_time : Optional[bool]
             A boolean flag that determines the method of fetching analysis-assimilation

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -250,11 +250,8 @@ def fetch_and_format_nwm_grids(
         )
         z_hour_df.sort_values([LOCATION_ID, VALUE_TIME], inplace=True)
 
-        if convert_k_to_c:
-            z_hour_df = convert_value_from_kelvin_to_celsius(
-                df=z_hour_df,
-                variable_name=variable_name
-            )
+        if convert_k_to_c and variable_name == "T2D":
+            z_hour_df = convert_value_from_kelvin_to_celsius(df=z_hour_df)
 
         if drop_overlapping_assimilation_values and "assim" in nwm_configuration_name:
             # Set reference_time to NaT for assimilation values

--- a/src/teehr/fetching/nwm/grid_utils.py
+++ b/src/teehr/fetching/nwm/grid_utils.py
@@ -123,8 +123,7 @@ def process_single_nwm_grid_file(
     """Fetch data for a single reference file and compute weighted average."""
     ds = get_dataset(
         row.filepath,
-        ignore_missing_file,
-        remote_options={"token": "anon"}
+        ignore_missing_file
     )
     if not ds:
         return None

--- a/src/teehr/fetching/nwm/nwm_grids.py
+++ b/src/teehr/fetching/nwm/nwm_grids.py
@@ -47,7 +47,7 @@ def nwm_grids_to_parquet(
     end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
     ingest_days: Optional[int] = None,
     data_source: Optional[SupportedNWMDataSourcesEnum] = "GCS",
-    kerchunk_method: Optional[SupportedKerchunkMethod] = "local",
+    kerchunk_method: Optional[SupportedKerchunkMethod] = "auto",
     prioritize_analysis_value_time: Optional[bool] = False,
     t_minus_hours: Optional[List[int]] = None,
     ignore_missing_file: Optional[bool] = True,
@@ -117,11 +117,11 @@ def nwm_grids_to_parquet(
         Currently only "GCS" is implemented.
     kerchunk_method : Optional[SupportedKerchunkMethod]
         When data_source = "GCS", specifies the preference in creating Kerchunk
-        reference json files. "local" (default) will create new json files from
+        reference json files. "local" - create new json files from
         netcdf files in GCS and save to a local directory if they do not already
         exist locally, in which case the creation is skipped. "remote" - read the
         CIROH pre-generated jsons from s3, ignoring any that are unavailable.
-        "auto" - read the CIROH pre-generated jsons from s3, and create any that
+        "auto" (default) - read the CIROH pre-generated jsons from s3, and create any that
         are unavailable, storing locally.
     prioritize_analysis_value_time : Optional[bool]
         A boolean flag that determines the method of fetching analysis data.
@@ -368,7 +368,6 @@ def nwm_grids_to_parquet(
             template_ds = get_dataset(
                 json_paths[0],
                 ignore_missing_file=False,
-                remote_options={"token": "anon"}
             )
 
             generate_weights_file(

--- a/src/teehr/fetching/nwm/nwm_grids.py
+++ b/src/teehr/fetching/nwm/nwm_grids.py
@@ -16,7 +16,8 @@ from teehr.fetching.utils import (
     start_on_z_hour,
     end_on_z_hour,
     get_dataset,
-    get_end_date_from_ingest_days
+    get_end_date_from_ingest_days,
+    log_temperature_conversion_message
 )
 from teehr.models.fetching.utils import (
     SupportedNWMOperationalVersionsEnum,
@@ -258,6 +259,11 @@ def nwm_grids_to_parquet(
 
     if isinstance(end_date, str):
         end_date = parse(end_date)
+
+    log_temperature_conversion_message(
+        variable_name=variable_name,
+        convert_k_to_c=convert_k_to_c
+    )
 
     # Import appropriate config model and dicts based on NWM version
     if nwm_version == SupportedNWMOperationalVersionsEnum.nwm12:

--- a/src/teehr/fetching/nwm/nwm_points.py
+++ b/src/teehr/fetching/nwm/nwm_points.py
@@ -48,7 +48,7 @@ def nwm_to_parquet(
     end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
     ingest_days: Optional[int] = None,
     data_source: Optional[SupportedNWMDataSourcesEnum] = "GCS",
-    kerchunk_method: Optional[SupportedKerchunkMethod] = "local",
+    kerchunk_method: Optional[SupportedKerchunkMethod] = "auto",
     prioritize_analysis_value_time: Optional[bool] = False,
     t_minus_hours: Optional[List[int]] = None,
     process_by_z_hour: Optional[bool] = True,
@@ -111,11 +111,11 @@ def nwm_to_parquet(
         Currently only "GCS" is implemented.
     kerchunk_method : Optional[SupportedKerchunkMethod]
         When data_source = "GCS", specifies the preference in creating Kerchunk
-        reference json files. "local" (default) will create new json files from
+        reference json files. "local" - create new json files from
         netcdf files in GCS and save to a local directory if they do not already
         exist locally, in which case the creation is skipped. "remote" - read the
         CIROH pre-generated jsons from s3, ignoring any that are unavailable.
-        "auto" - read the CIROH pre-generated jsons from s3, and create any that
+        "auto" (default) - read the CIROH pre-generated jsons from s3, and create any that
         are unavailable, storing locally.
     prioritize_analysis_value_time : Optional[bool]
         A boolean flag that determines the method of fetching analysis data.

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -65,7 +65,7 @@ def file_chunk_loop(
         + pd.to_timedelta(int(row.z_hour[1:3]), unit="h")
 
     valid_time = ds.time.values
-    feature_ids = ds.feature_id.values
+    feature_ids = ds.feature_id.values.astype(int)
     teehr_location_ids = \
         [f"{nwm_version}-{feat_id}" for feat_id in feature_ids]
     num_vals = vals.size

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -1,6 +1,7 @@
 """Module defining shared functions for processing NWM point data."""
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
+import re
 
 import dask
 import numpy as np
@@ -144,17 +145,17 @@ def process_chunk_of_files(
     output = [tbl for tbl in output if tbl is not None]
     output_table = pa.concat_tables(output)
 
+    df.sort_values(by="filepath", inplace=True)
     if process_by_z_hour:
         row = df.iloc[0]
         filename = f"{row.day}T{row.z_hour[1:3]}.parquet"
     else:
         # Use start and end dates including forecast hour
         #  for the output file name.
-        filepath_list = df.filepath.sort_values().tolist()
-        start_json = filepath_list[0].split("/")[-1].split(".")
-        start = f"{start_json[1]}T{start_json[3][1:3]}F{start_json[6][1:]}"
-        end_json = filepath_list[-1].split("/")[-1].split(".")
-        end = f"{end_json[1]}T{end_json[3][1:3]}F{end_json[6][1:]}"
+        start_forecast_hour = re.search(r'\.f(\d+)\.', df.filepath.iloc[0]).group(1)
+        end_forecast_hour = re.search(r'\.f(\d+)\.', df.filepath.iloc[-1]).group(1)
+        start = f"{df.day.iloc[0]}T{df.z_hour.iloc[0][1:3]}F{start_forecast_hour}"
+        end = f"{df.day.iloc[-1]}T{df.z_hour.iloc[-1][1:3]}F{end_forecast_hour}"
         filename = f"{start}_{end}.parquet"
 
     if drop_overlapping_assimilation_values and "assim" in configuration:

--- a/src/teehr/fetching/nwm/point_utils.py
+++ b/src/teehr/fetching/nwm/point_utils.py
@@ -150,12 +150,18 @@ def process_chunk_of_files(
         row = df.iloc[0]
         filename = f"{row.day}T{row.z_hour[1:3]}.parquet"
     else:
-        # Use start and end dates including forecast hour
-        #  for the output file name.
-        start_forecast_hour = re.search(r'\.f(\d+)\.', df.filepath.iloc[0]).group(1)
-        end_forecast_hour = re.search(r'\.f(\d+)\.', df.filepath.iloc[-1]).group(1)
-        start = f"{df.day.iloc[0]}T{df.z_hour.iloc[0][1:3]}F{start_forecast_hour}"
-        end = f"{df.day.iloc[-1]}T{df.z_hour.iloc[-1][1:3]}F{end_forecast_hour}"
+        # Use start and end dates including forecast hour or t-minus hour (assimilation)
+        # for the output file name.
+        if "assim" in configuration:
+            start_tm_hour = re.search(r'\.tm(\d+)\.', df.filepath.iloc[0]).group(1)
+            end_tm_hour = re.search(r'\.tm(\d+)\.', df.filepath.iloc[-1]).group(1)
+            start = f"{df.day.iloc[0]}T{df.z_hour.iloc[0][1:3]}M{start_tm_hour}"
+            end = f"{df.day.iloc[-1]}T{df.z_hour.iloc[-1][1:3]}M{end_tm_hour}"
+        else:
+            start_forecast_hour = re.search(r'\.f(\d+)\.', df.filepath.iloc[0]).group(1)
+            end_forecast_hour = re.search(r'\.f(\d+)\.', df.filepath.iloc[-1]).group(1)
+            start = f"{df.day.iloc[0]}T{df.z_hour.iloc[0][1:3]}F{start_forecast_hour}"
+            end = f"{df.day.iloc[-1]}T{df.z_hour.iloc[-1][1:3]}F{end_forecast_hour}"
         filename = f"{start}_{end}.parquet"
 
     if drop_overlapping_assimilation_values and "assim" in configuration:

--- a/src/teehr/fetching/nwm/retrospective_grids.py
+++ b/src/teehr/fetching/nwm/retrospective_grids.py
@@ -69,7 +69,8 @@ from teehr.fetching.utils import (
     get_dataset,
     get_period_start_end_times,
     create_periods_based_on_chunksize,
-    convert_value_from_kelvin_to_celsius
+    convert_value_from_kelvin_to_celsius,
+    log_temperature_conversion_message
 )
 from teehr.fetching.nwm.retrospective_points import (
     format_grouped_filename,
@@ -332,6 +333,11 @@ def nwm_retro_grids_to_parquet(
 
     validate_retrospective_start_end_date(nwm_version, start_date, end_date)
 
+    log_temperature_conversion_message(
+        variable_name=variable_name,
+        convert_k_to_c=convert_k_to_c
+    )
+
     output_dir = Path(output_parquet_dir)
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
@@ -427,11 +433,8 @@ def nwm_retro_grids_to_parquet(
                                         "configuration were found in GCS!")
             chunk_df = pd.concat(output)
 
-            if convert_k_to_c:
-                chunk_df = convert_value_from_kelvin_to_celsius(
-                    df=chunk_df,
-                    variable_name=variable_name
-                )
+            if convert_k_to_c and variable_name == "T2D":
+                chunk_df = convert_value_from_kelvin_to_celsius(df=chunk_df)
 
             start = df.datetime.min().strftime("%Y%m%d")
             end = df.datetime.max().strftime("%Y%m%d")
@@ -520,11 +523,8 @@ def nwm_retro_grids_to_parquet(
                 variable_mapper=variable_mapper
             )
 
-            if convert_k_to_c:
-                chunk_df = convert_value_from_kelvin_to_celsius(
-                    df=chunk_df,
-                    variable_name=variable_name
-                )
+            if convert_k_to_c and variable_name == "T2D":
+                chunk_df = convert_value_from_kelvin_to_celsius(df=chunk_df)
 
             fname = format_grouped_filename(da_i)
             output_filename = Path(

--- a/src/teehr/fetching/utils.py
+++ b/src/teehr/fetching/utils.py
@@ -987,7 +987,7 @@ def split_dataframe(df: pd.DataFrame, chunk_size: int) -> List[pd.DataFrame]:
     return chunks
 
 
-def convert_value_from_kelvin_to_celsius(df: pd.DataFrame, variable_name: str) -> pd.DataFrame:
+def convert_value_from_kelvin_to_celsius(df: pd.DataFrame) -> pd.DataFrame:
     """Convert temperature values from Kelvin to Celsius for a specific variable.
 
     Parameters
@@ -1002,15 +1002,28 @@ def convert_value_from_kelvin_to_celsius(df: pd.DataFrame, variable_name: str) -
     pd.DataFrame
         The dataframe with converted temperature values.
     """
-    if variable_name == "T2D":
-        logger.info(
-            "Converting temperature values from Kelvin to Celsius for variable T2D"
-        )
-        df["value"] = df["value"] - 273.15
-        df.loc[:, UNIT_NAME] = "C"
-    else:
-        logger.warning(
-            "The convert_k_to_c flag is set to True but the variable being processed is not T2D."
-            " No conversion will be applied."
-        )
+    df["value"] = df["value"] - 273.15
+    df.loc[:, UNIT_NAME] = "C"
     return df
+
+
+def log_temperature_conversion_message(
+    variable_name: str,
+    convert_k_to_c: bool
+):
+    """Log the conversion of temperature values from Kelvin to Celsius."""
+    if variable_name == "T2D" and convert_k_to_c:
+        logger.info(
+            f"Temperature values for {variable_name} will be converted from Kelvin to Celsius."
+        )
+    elif variable_name == "T2D" and not convert_k_to_c:
+        logger.warning(
+            f"Temperature values for {variable_name} will be kept in Kelvin."
+            " If you would like to convert to Celsius, set 'convert_k_to_c=True'."
+        )
+    elif variable_name != "T2D" and convert_k_to_c:
+        logger.warning(
+            "Temperature conversion from Kelvin to Celsius is only applicable for the variable 'T2D'."
+            f" The variable you are fetching is {variable_name}, so no conversion will be applied."
+            " Set 'convert_k_to_c=False' to suppress this warning."
+        )

--- a/tests/fetch/test_fetch_and_load.py
+++ b/tests/fetch/test_fetch_and_load.py
@@ -90,8 +90,6 @@ def test_fetch_and_load_nwm_retro_points(function_scope_evaluation_template):
     assert sts_df.value_time.min() == pd.Timestamp("2022-02-22 00:00:00")
     assert sts_df.value_time.max() == pd.Timestamp("2022-02-25 23:00:00")
 
-    # ev.spark.stop()
-
 
 @pytest.mark.function_scope_evaluation_template
 def test_fetch_and_load_nwm_retro_grids(function_scope_evaluation_template):
@@ -125,8 +123,6 @@ def test_fetch_and_load_nwm_retro_grids(function_scope_evaluation_template):
     assert np.isclose(ts_df.value.sum(), np.float32(0.00028349122))
     assert ts_df.value_time.min() == pd.Timestamp("2008-05-23 09:00:00")
     assert ts_df.value_time.max() == pd.Timestamp("2008-05-23 10:00:00")
-
-    # ev.spark.stop()
 
 
 @pytest.mark.function_scope_evaluation_template
@@ -186,10 +182,7 @@ def test_fetch_and_load_nwm_operational_points(function_scope_evaluation_templat
     assert updated_df.value_time.max() == pd.Timestamp("2024-02-23 06:00:00")
     assert np.isclose(updated_df.value.sum(), np.float32(492485.03))
 
-    # ev.spark.stop()
 
-
-@pytest.mark.skip(reason="This takes forever!")
 def test_fetch_and_load_nwm_operational_grids(tmpdir):
     """Test the NWM forecast grids fetch and load."""
     ev = LocalReadWriteEvaluation(dir_path=tmpdir, create_dir=True)
@@ -209,7 +202,8 @@ def test_fetch_and_load_nwm_operational_grids(tmpdir):
         location_id_prefix="huc10",
         calculate_zonal_weights=True,
         starting_z_hour=2,
-        ending_z_hour=22
+        ending_z_hour=22,
+        kerchunk_method="auto"
     )
     ts_df = ev.primary_timeseries.to_pandas()
 

--- a/tests/fetch/test_fetch_and_load.py
+++ b/tests/fetch/test_fetch_and_load.py
@@ -153,6 +153,7 @@ def test_fetch_and_load_nwm_operational_points(function_scope_evaluation_templat
         process_by_z_hour=False,
         starting_z_hour=3,
         ending_z_hour=20,
+        kerchunk_method="auto"
     )
     ts_df = ev.secondary_timeseries.to_pandas()
 

--- a/tests/fetch/test_fetch_and_load.py
+++ b/tests/fetch/test_fetch_and_load.py
@@ -183,6 +183,7 @@ def test_fetch_and_load_nwm_operational_points(function_scope_evaluation_templat
     assert np.isclose(updated_df.value.sum(), np.float32(492485.03))
 
 
+@pytest.mark.skip(reason="This one takes a long time, test manually as needed.")
 def test_fetch_and_load_nwm_operational_grids(tmpdir):
     """Test the NWM forecast grids fetch and load."""
     ev = LocalReadWriteEvaluation(dir_path=tmpdir, create_dir=True)


### PR DESCRIPTION
- This fixes a file-naming issue for files being written to the cache during NWM operational streamflow fetching using CIROH-generated kerchunk files
- Also moves the logging messages related to temperature unit conversion from K to C to be outside the processing loop, so they don't get logged every iteration 