### PR TITLE
feat: update usgs variable name; add variable name migrations

### DIFF
--- a/docs/sphinx/changelog/index.md
+++ b/docs/sphinx/changelog/index.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## 0.6.6 - 2026-07-28
+
+### Added
+- Added migration scripts in `src/teehr/migrations/0010` to rename `streamflow_hourly_inst` to `streamflow_none_inst` in `primary_timeseries`.
+
+### Changed
+- None
+
+### Fixed
+- Renamed `streamflow_hourly_inst` to `streamflow_none_inst` in USGS fetching
+
+### Dependencies
+- None
+
+### Deprecated
+- None
+
 ## 0.6.5 - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "teehr"
-version = "0.6.5"
+version = "0.6.6"
 description = "Tools for Exploratory Evaluation in Hydrologic Research"
 authors = [
     "RTI International",

--- a/src/teehr/__init__.py
+++ b/src/teehr/__init__.py
@@ -1,7 +1,7 @@
 """Initialize the TEEHR package."""
 import warnings
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", UserWarning)

--- a/src/teehr/fetching/const.py
+++ b/src/teehr/fetching/const.py
@@ -26,7 +26,7 @@ NWM_S3_JSON_PATH = "s3://ciroh-nwm-zarr-copy"
 
 USGS_VARIABLE_MAPPER = {
     VARIABLE_NAME: {
-        "iv": "streamflow_hourly_inst",
+        "iv": "streamflow_none_inst",
         "dv": "streamflow_daily_mean",
     },
     UNIT_NAME: {

--- a/src/teehr/migrations/0008/01_update_variables_table.sql
+++ b/src/teehr/migrations/0008/01_update_variables_table.sql
@@ -1,0 +1,2 @@
+INSERT INTO variables VALUES
+    ("streamflow_none_inst", "Instantaneous Streamflow", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/teehr/migrations/0008/02_update_variable_name.sql
+++ b/src/teehr/migrations/0008/02_update_variable_name.sql
@@ -1,0 +1,3 @@
+UPDATE primary_timeseries
+SET variable_name = 'streamflow_none_inst'
+WHERE variable_name = 'streamflow_hourly_inst'


### PR DESCRIPTION
- Changes the variable_name for usgs observations from `streamflow_hourly_inst` to `streamflow_none_inst`
- Add migrations to add the variable name and rename it in the warehouse tables

Note: The failing test should be fixed in https://github.com/RTIInternational/teehr/pull/799