### PR TITLE
804 fix sdot denominator in resops metrics

### DIFF
--- a/docs/sphinx/user_guide/metrics/metrics.rst
+++ b/docs/sphinx/user_guide/metrics/metrics.rst
@@ -335,7 +335,7 @@ Signatures operate on a single field to characterize timeseries properties.
    * - :material-regular:`check;1.5em;sd-text-success`
      - Standard Deviation of Timing
      - :math:`Std\ Dev\ of\ Timing`
-     - :math:`\sqrt{\frac{\sum(prim_i \cdot (t_i - CenterOfTiming)^2)}{\sum(prim_i)}}`
+     - :math:`\sqrt{\frac{\sum(prim_i \cdot (t_i - CenterOfTiming)^2)}{\frac{\sum(prim_i)\cdot(n^{\prime}-1)}{n^{\prime}}}}`
      - :class:`Standard Deviation of Timing <teehr.Signatures.StandardDeviationOfTiming>`
 
 

--- a/src/teehr/metrics/signature_funcs.py
+++ b/src/teehr/metrics/signature_funcs.py
@@ -432,7 +432,7 @@ def standard_deviation_of_timing(model: MetricsBasemodel) -> Callable:
 
             # Calculate SDoT
             SDoT_numerator = np.sum(p_nz * (WY_days_nz - CT)**2)
-            SDoT_denominator = sum_p_nz * (n_prime - 1)
+            SDoT_denominator = (sum_p_nz * (n_prime - 1))/n_prime
 
             if model.add_epsilon:
                 SDoT = np.sqrt(SDoT_numerator / (SDoT_denominator + EPSILON))

--- a/src/teehr/metrics/spark_native.py
+++ b/src/teehr/metrics/spark_native.py
@@ -809,7 +809,7 @@ def _compute_standard_deviation_of_timing_metric(
         F.col("_sum_pd2")
         - (F.col("_sum_pw") * F.col("_sum_pw") / F.col("_sum_p"))
     )
-    denominator = F.col("_sum_p") * (F.col("_n_prime") - F.lit(1))
+    denominator = (F.col("_sum_p") * (F.col("_n_prime") - F.lit(1))) / F.col("_n_prime")
     if metric.add_epsilon:
         denominator = denominator + F.lit(EPSILON)
 

--- a/tests/query/test_metrics_aggregate.py
+++ b/tests/query/test_metrics_aggregate.py
@@ -110,8 +110,16 @@ def test_resops_signatures(module_scope_resops_signatures_test_warehouse):
     ev = module_scope_resops_signatures_test_warehouse
 
     # Now, metrics.
-    ct = Signatures.CenterOfTiming(primary_field_name='value')
-    sdot = Signatures.StandardDeviationOfTiming(primary_field_name='value')
+    min_days = 329
+    missing_day_threshold = 1 - (min_days / 365)
+    ct = Signatures.CenterOfTiming(
+        primary_field_name='value',
+        missing_day_threshold=missing_day_threshold
+    )
+    sdot = Signatures.StandardDeviationOfTiming(
+        primary_field_name='value',
+        missing_day_threshold=missing_day_threshold
+    )
 
     # execute using spark engine
     spark_df = ev.table(
@@ -150,7 +158,7 @@ def test_resops_signatures(module_scope_resops_signatures_test_warehouse):
     )
     assert np.isclose(
         spark_df.standard_deviation_of_timing.values[0],
-        3.928218
+        75.048500
     )
 
     # check python and spark engines give same result


### PR DESCRIPTION
- corrects error in the denominator of SDoT
- updates tests to reflect the new expected value (verified against a script provided by CSMines)
- corrects the SDoT equation in the docs to reflect the change

closes #804 