### PR TITLE
fix: bump AWS SDK bundle to 2.33.0 to match Iceberg 1.10.1

### DIFF
--- a/src/teehr/evaluation/spark_session_utils.py
+++ b/src/teehr/evaluation/spark_session_utils.py
@@ -324,7 +324,18 @@ def _create_spark_base_session(
         f"org.apache.iceberg:iceberg-spark-runtime-{PYSPARK_VERSION}_{SCALA_VERSION}:{ICEBERG_VERSION}",
         "org.datasyslab:geotools-wrapper:1.8.0-33.1",
         f"org.apache.iceberg:iceberg-spark-extensions-{PYSPARK_VERSION}_{SCALA_VERSION}:{ICEBERG_VERSION}",
-        "software.amazon.awssdk:bundle:2.24.6",
+        # Must stay >= the AWS SDK that ICEBERG_VERSION is built against
+        # (Iceberg 1.10.1 -> 2.33.0). Iceberg's VendedCredentialsProvider, used
+        # for the Polaris/STS vended-credential path, calls
+        # IoUtils.closeQuietlyV2, which does not exist before ~2.30. On 2.24.6
+        # every Iceberg broadcast cleanup threw NoSuchMethodError on a Spark
+        # daemon thread and killed the executor with exit code 50.
+        #
+        # This is deliberately newer than the 2.24.6 hadoop-aws 3.4.1 pulls in
+        # transitively; declaring it explicitly lets Ivy's latest-revision
+        # conflict resolution put a single, new-enough SDK on the classpath for
+        # both Iceberg and S3A.
+        "software.amazon.awssdk:bundle:2.33.0",
         "org.apache.hadoop:hadoop-aws:3.4.1",  # Note. Need 3.4.1 for compatibility
         "com.amazonaws:aws-java-sdk-bundle:1.12.791",
         "org.xerial:sqlite-jdbc:3.42.0.0"


### PR DESCRIPTION
## Problem

Every Spark executor in the `update-joined-forecast-table-incremental` Prefect workflow was dying with exit code 50:

```
ERROR SparkUncaughtExceptionHandler: Uncaught exception in thread block-manager-storage-async-thread-pool
java.lang.NoSuchMethodError: 'void software.amazon.awssdk.utils.IoUtils.closeQuietlyV2(...)'
	at org.apache.iceberg.aws.s3.VendedCredentialsProvider.close(VendedCredentialsProvider.java:77)
	at org.apache.iceberg.aws.s3.S3FileIO.close(S3FileIO.java:526)
	at org.apache.iceberg.spark.source.SerializableTableWithSize.close(...)
	at org.apache.spark.storage.memory.MemoryStore.freeMemoryEntry(...)
	at org.apache.spark.storage.BlockManager.removeBroadcast(...)
```

`ICEBERG_VERSION` is `1.10.1`, which is built against AWS SDK **2.33.0** (per Iceberg's `gradle/libs.versions.toml` at `apache-iceberg-1.10.1`). The classpath pinned `software.amazon.awssdk:bundle:2.24.6` — the version `hadoop-aws:3.4.1` is built against. Verified with `javap`: `IoUtils.closeQuietlyV2` is absent in 2.24.6 and present in 2.33.0.

`VendedCredentialsProvider` is the Polaris/STS vended-credential path, so this only became reachable with the Polaris migration.

## Why it looked like a Spark session crash

The error fires whenever Spark frees a broadcast block holding an Iceberg table object — routine cleanup after each batch. So executors died steadily:

1. Executor JVM dies with exit code 50 (uncaught exception on a daemon thread).
2. `ExecutorPodsLifecycleManager` counts failures; past `spark.executor.maxNumFailures` it calls `sys.exit()`.
3. That's a graceful JVM exit, so shutdown hooks run `SparkContext.stop()` — surfacing to the flow as `Job cancelled because SparkContext was shut down`, then `No active or default Spark session found` on Prefect's retries.

The threshold is `max(3, 2 × executor_instances)`. The incremental flow uses 8 executors → 16. A narrowed two-batch repro produced exactly 16 executor deaths; the full 27-batch run blows past it and dies early.

Not a data-volume problem: the planner's batches were 2,556 and 3,924 rows.

## Fix

Bump the explicit pin to 2.33.0.

Considered and rejected: swapping to `org.apache.iceberg:iceberg-aws-bundle`. It ships no `software/amazon/awssdk/transfer/s3`, and Hadoop S3A 3.4.x requires `S3TransferManager` — that would trade this bug for a `NoClassDefFoundError` on every `fs.s3a.*` path. Keeping the full bundle gives one complete SDK to both Iceberg and S3A, and declaring 2.33.0 explicitly lets Ivy's latest-revision conflict resolution beat the 2.24.6 that `hadoop-aws:3.4.1` pulls in transitively.

## Testing

Worth a smoke test of a non-Iceberg `fs.s3a.*` read (external buckets / gridded ingest), since `hadoop-aws:3.4.1` was compiled against 2.24.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)