### PR TITLE
Fix bootstrap NaN/ddof semantics, make the vectorized engine the default, add 18 kernels

### DIFF
--- a/docs/sphinx/changelog/index.md
+++ b/docs/sphinx/changelog/index.md
@@ -3,6 +3,18 @@
 ## Unreleased
 
 ### Breaking Changes
+- **Metrics that depend on `value_time` can no longer be bootstrapped.** `MaxValueTimeDelta`,
+  `AnnualPeakRelativeBias`, `MaxValueTime`, `CenterOfTiming` and
+  `StandardDeviationOfTiming` now raise a `ValueError` if given a `bootstrap` config.
+  Resampling reorders and repeats observations, so the time axis these metrics are defined on
+  no longer corresponds to the values beside it — the result is undefined rather than merely
+  imprecise. The combination did not work before either, it just failed inconsistently:
+  `MaxValueTimeDelta` and `MaxValueTime` raised, while the other three returned numbers
+  computed on a scrambled time axis. Under `Gumboot` all five raised, because the bootstrapper
+  consumes the trailing `value_time` argument for its own water-year blocking and never
+  forwards it to the metric. Supporting these under `Gumboot` — where water-year resampling
+  *does* preserve within-year time structure — would require plumbing `value_time` through to
+  the metric and reconstructing the resampled timestamps, and is not part of this change.
 - **Non-finite values are now dropped from every metric, not just transformed ones.**
   `deterministic_funcs._transform` used to drop non-finite `(primary, secondary)` pairs only
   when a `transform` was set, making it the one metric path in TEEHR that kept them. What that

--- a/docs/sphinx/changelog/index.md
+++ b/docs/sphinx/changelog/index.md
@@ -59,6 +59,18 @@
   `start_inclusive` / `end_exclusive` spellings are still accepted, but they name a
   behaviour that `closed` now controls, so the generic keys are preferred.
 
+### Added
+- Bootstrap quality guards are now configurable on the `Bootstrappers` models:
+  `minimum_sample_size` (default 30), `minimum_mean` (0.01) and `minimum_variance`
+  (0.000025). A group failing any of them returns null for every metric sharing the config.
+  The thresholds were previously hardcoded with no user-facing override. They live on the
+  bootstrap config rather than the aggregation call because that is what they describe, and
+  because `bootstrap_group_key` already keys groups on the config — so they are now part of
+  that key, and two configs differing only in a guard no longer share a group. Note that for
+  `Gumboot` the meaningful sample size is the number of water years rather than timesteps,
+  while the guard measures input series length, so callers resampling few water years may
+  want to raise `minimum_sample_size` explicitly.
+
 ### Changed
 - **Bootstrapped metrics now use the vectorized engine by default**, roughly 19x faster than
   the per-replicate loop for a group of covered metrics (measured at n=1000, reps=1000). Set

--- a/docs/sphinx/changelog/index.md
+++ b/docs/sphinx/changelog/index.md
@@ -60,6 +60,15 @@
   behaviour that `closed` now controls, so the generic keys are preferred.
 
 ### Added
+- `DeterministicMetrics.VariabilityRatio` is now reachable. The metric was implemented,
+  announced in a previous release, documented in the user guide (with a `:class:` reference to
+  `teehr.DeterministicMetrics.VariabilityRatio`), tested for Spark/pandas parity and supported
+  on the Spark-native path — but was never added to the `DeterministicMetrics` container, so
+  following the documentation raised `AttributeError`. Its `display_name` is corrected from
+  "Variance Ratio" to "Variability Ratio", since the formula is a ratio of standard
+  deviations. It also gains a vectorized bootstrap kernel. Note its formula is identical to
+  `RelativeStandardDeviation`; whether the two should remain separate metrics is tracked
+  separately.
 - Bootstrap quality guards are now configurable on the `Bootstrappers` models:
   `minimum_sample_size` (default 30), `minimum_mean` (0.01) and `minimum_variance`
   (0.000025). A group failing any of them returns null for every metric sharing the config.

--- a/docs/sphinx/changelog/index.md
+++ b/docs/sphinx/changelog/index.md
@@ -3,6 +3,34 @@
 ## Unreleased
 
 ### Breaking Changes
+- **Non-finite values are now dropped from every metric, not just transformed ones.**
+  `deterministic_funcs._transform` used to drop non-finite `(primary, secondary)` pairs only
+  when a `transform` was set, making it the one metric path in TEEHR that kept them. What that
+  meant in practice depended on which NumPy call a metric happened to use, because the
+  closures receive `pd.Series`: `np.sum`/`mean`/`std`/`min`/`max` dispatch to pandas and skip
+  NaN, while `np.median`/`np.cov`/`np.corrcoef` propagate it. So `relative_mean` ignored a gap
+  while `pearson_correlation` returned NaN for the same input, and `len(p)` in the
+  mean-error family counted rows the reduction above it had just skipped. Dropping is now
+  unconditional, matching `signature_funcs` and the Spark-native engine, which both already
+  did this. **Metric values change for any evaluation with gaps in the joined timeseries**,
+  and the ME/MAE/MSE/RMSE denominators are now the valid-pair count rather than the raw row
+  count.
+- **`pearson_correlation` and `r_squared` with `add_epsilon=True` return corrected values.**
+  That branch divided a `ddof=1` covariance (`np.cov`'s default) by `ddof=0` standard
+  deviations. Those do not cancel, so the result was `r * n/(n-1)` — which exceeds 1.0 on
+  small well-correlated samples (1.110 at n=10) and is therefore not a correlation
+  coefficient at all. Both paths now use a consistent `ddof=0`, matching the Spark-native
+  engine, which already paired `covar_pop` with `stddev_pop`. Values shift by `n/(n-1)` for
+  `pearson_correlation` and `(n/(n-1))²` for `r_squared`; the `add_epsilon=False` branch
+  (`np.corrcoef`) was already correct and is unchanged.
+- **Bootstrap quality guards now apply to single-metric requests.** The sample-size (n < 30),
+  mean (< 0.01) and variance (< 2.5e-5) guards lived on the shared-bootstrap path, which
+  groups of one bypassed. One bootstrapped metric would therefore compute on a 5-sample group
+  while the same metric requested alongside a second one returned nulls for both. All
+  bootstrap groups now take the same path, so small or degenerate groups that previously
+  returned a value will return null. Note a "group of one" is a *bootstrap-config* group —
+  metrics with different seeds, reps, quantiles or input fields do not share one, so several
+  bootstrapped metrics can still produce several singleton groups.
 - **`ForecastLeadTimeBins` lead time bins are now start-exclusive and end-inclusive**
   (`closed="right"`, the new default). A lead time of exactly one bin width now falls in the
   *first* bin, so an 18-hour forecast binned at 6 hours yields three bins covering hours
@@ -20,10 +48,28 @@
   behaviour that `closed` now controls, so the generic keys are preferred.
 
 ### Changed
+- **Bootstrapped metrics now use the vectorized engine by default**, roughly 19x faster than
+  the per-replicate loop for a group of covered metrics (measured at n=1000, reps=1000). Set
+  `TEEHR_BOOTSTRAP_ENGINE=legacy` to fall back; on a Spark cluster that must be set on the
+  executors (`spark.executorEnv.TEEHR_BOOTSTRAP_ENGINE`), since the check runs inside the
+  pandas UDF. The two engines are numerically identical — verified bit-for-bit at reps=1000,
+  and to ~1e-15 once input dtype is held equal.
+- The vectorized bootstrap covers 27 metrics, up from 9: 21 of 31 deterministic and 6 of 10
+  signature. Metrics without a kernel now fall back **per metric** rather than forcing their
+  whole bootstrap group onto the legacy loop, which previously cost a mixed group ~8x.
+- Bootstrapped metrics accumulate in float64. Values are stored as float32, and the legacy
+  loop reduced in float32; results can therefore differ in the last couple of float32 ULPs
+  from previous releases (more under a `log` transform, which amplifies the input error).
 - `unpack_sdf_dict_columns` accepts an optional `key_list` argument to expand a MapType column without reading its keys from the data.
 - `unpack_sdf_dict_columns` raises a clear `ValueError` when asked to unpack a non-MapType column, instead of an `AttributeError`.
 
 ### Fixed
+- A repeated bootstrap quantile (e.g. `quantiles=[0.5, 0.50]`) no longer raises
+  `DUPLICATED_MAP_KEY` when the shared-bootstrap map is expanded. The UDF's dict collapses the
+  repeat, but the map reconstruction emitted the key twice.
+- A bootstrapped threshold metric with `threshold_field_name=None` now raises the same
+  explicit `ValueError` as the non-bootstrap path, instead of an opaque `TypeError` from
+  inside the UDF.
 - A forecast lead time that falls outside every bin now yields NULL instead of being folded
   into the first bin. Previously the uniform-bin path cast a truncating division, so a
   negative lead time silently landed in bin 0.

--- a/src/teehr/metrics/bootstrap_funcs.py
+++ b/src/teehr/metrics/bootstrap_funcs.py
@@ -209,6 +209,13 @@ def bootstrap_group_key(metric: MetricsBasemodel) -> Optional[tuple]:
         quantile_key,
         boot.include_value_time,
         fields,
+        # The guards must be part of the key. create_shared_bootstrap_func
+        # reads them from metrics[0].bootstrap, so two configs differing only
+        # in a guard would otherwise share a group and the first metric's
+        # thresholds would silently apply to the rest.
+        boot.minimum_sample_size,
+        boot.minimum_mean,
+        boot.minimum_variance,
     )
 
     # Method-specific extra fields
@@ -300,25 +307,16 @@ def _make_bs_object(boot, args):
 
 def create_shared_bootstrap_func(
     metrics: List[MetricsBasemodel],
-    minimum_sample_size: int = 30,
-    minimum_mean: float = 0.01,
-    minimum_variance: float = 0.000025,
 ) -> Callable:
     """Create a single bootstrap UDF that evaluates multiple metrics per draw.
 
     All metrics in *metrics* must share the same bootstrap configuration
-    (same class, reps, seed, block_size, quantiles, and input fields).
+    (same class, reps, seed, block_size, quantiles, guards, and input fields).
 
     Parameters
     ----------
     metrics : List[MetricsBasemodel]
         Metrics sharing the same bootstrap config.
-    minimum_sample_size : int, optional
-        Minimum sample count to run bootstrap. Default 30.
-    minimum_mean : float, optional
-        Minimum mean value of primary series to run bootstrap. Default 0.01.
-    minimum_variance : float, optional
-        Minimum variance of primary series to run bootstrap. Default 0.000025.
 
     Returns
     -------
@@ -327,6 +325,13 @@ def create_shared_bootstrap_func(
     """
     # Reference bootstrap config from the first metric (all are equivalent).
     ref_boot = metrics[0].bootstrap
+
+    # Quality guards come from the bootstrap config rather than this call:
+    # they describe the resampling, and bootstrap_group_key already keys
+    # groups on the config, so metrics in a group necessarily share them.
+    minimum_sample_size = ref_boot.minimum_sample_size
+    minimum_mean = ref_boot.minimum_mean
+    minimum_variance = ref_boot.minimum_variance
 
     # Build per-metric inner functions once at UDF-creation time.
     metric_funcs = [m.func(m) for m in metrics]

--- a/src/teehr/metrics/bootstrap_funcs.py
+++ b/src/teehr/metrics/bootstrap_funcs.py
@@ -9,10 +9,11 @@ import numpy as np
 from teehr.metrics.models.base import MetricsBasemodel
 from teehr.metrics.vectorized_bootstrap_funcs import (
     VECTORIZED_BOOTSTRAP_METHODS,
-    VECTORIZED_METRIC_FUNCS,
+    assemble_bootstrap_output,
     compute_vectorized_shared_bootstrap,
+    is_vectorized_metric,
 )
-from teehr.querying.utils import bootstrap_quantile_key
+from teehr.querying.utils import bootstrap_quantile_key, parse_fields_to_list
 
 logger = logging.getLogger(__name__)
 
@@ -25,15 +26,56 @@ def _vectorized_engine_enabled() -> bool:
     return os.environ.get("TEEHR_BOOTSTRAP_ENGINE", "legacy").strip().lower() == "vectorized"
 
 
-def _can_use_vectorized_engine(ref_boot, metrics: List[MetricsBasemodel]) -> bool:
-    """Whether the vectorized path can safely handle this bootstrap/metric mix."""
-    if not _vectorized_engine_enabled():
-        return False
+def _vectorized_engine_available(ref_boot, metrics) -> bool:
+    """Group-level preconditions for the vectorized path.
+
+    These are properties of the bootstrap object and the group's input fields,
+    so they genuinely cannot be decided per metric:
+
+    - the resampler must expose arch's ``update_indices()`` contract. Gumboot
+      takes a ``rep`` argument and returns ragged per-water-year index blocks,
+      so no ``(reps, n)`` matrix exists for it at all.
+    - ``include_value_time`` adds a third positional arg that the kernels have
+      no slot for, and ``np.asarray(..., dtype=float)`` on datetimes is lossy.
+    - the field count must match the kernel contract: ``args[0]`` primary and
+      an optional ``args[1]`` secondary. This one is not redundant with the
+      registry -- e.g. ``Signatures.Average(secondary_field_name=...)`` yields
+      a two-field group whose scalar closure takes one argument, where legacy
+      raises TypeError but a kernel would quietly ignore ``s_mat`` and
+      succeed. Rejecting keeps the two paths' error behavior identical.
+    """
     if type(ref_boot).__name__ not in VECTORIZED_BOOTSTRAP_METHODS:
         return False
     if ref_boot.include_value_time:
         return False
-    return all(type(m).__name__ in VECTORIZED_METRIC_FUNCS for m in metrics)
+
+    ref = metrics[0]
+    if hasattr(ref, "get_input_field_names"):
+        n_fields = len(parse_fields_to_list(ref.get_input_field_names()))
+    else:
+        n_fields = len(parse_fields_to_list(ref.input_field_names))
+    expects_secondary = getattr(ref, "secondary_field_name", None) is not None
+    return n_fields == (2 if expects_secondary else 1)
+
+
+def _can_use_vectorized_engine(ref_boot, metrics: List[MetricsBasemodel]) -> bool:
+    """Whether the vectorized path can help this bootstrap/metric group.
+
+    ``any``, not ``all``: metrics without a kernel are evaluated by their own
+    scalar closure inside ``compute_vectorized_shared_bootstrap``, on the same
+    draws as the kernels. Requiring every metric to be covered meant one
+    uncovered metric cost the whole group an ~8x slowdown, and
+    ``bootstrap_group_key`` excludes metric class precisely so that unrelated
+    metrics *do* share a group.
+
+    A group with no covered metrics returns False and takes the untouched
+    ``bs.apply`` path, so nothing changes for it.
+    """
+    if not _vectorized_engine_enabled():
+        return False
+    if not _vectorized_engine_available(ref_boot, metrics):
+        return False
+    return any(is_vectorized_metric(m) for m in metrics)
 
 
 def _optimal_block_size(data: np.ndarray, method: str = "stationary") -> int:
@@ -305,7 +347,7 @@ def create_shared_bootstrap_func(
 
         if _can_use_vectorized_engine(ref_boot, metrics):
             return compute_vectorized_shared_bootstrap(
-                metrics, args, bs, ref_boot.reps, quantiles
+                metrics, metric_funcs, args, bs, ref_boot.reps, quantiles
             )
 
         # Each draw: evaluate ALL metric functions and return a list.
@@ -317,15 +359,7 @@ def create_shared_bootstrap_func(
         # results shape: (reps, N_metrics)
         results = bs.apply(combined_func, ref_boot.reps)
 
-        combined_dict: Dict[str, Any] = {}
-        for i, name in enumerate(output_names):
-            if quantiles is None:
-                combined_dict[name] = np.asarray(results[:, i], dtype=float).tolist()
-            else:
-                combined_dict.update(
-                    _calculate_quantiles(name, results[:, i], quantiles)
-                )
-        return combined_dict
+        return assemble_bootstrap_output(output_names, results, quantiles)
 
     return shared_bootstrap_func
 

--- a/src/teehr/metrics/bootstrap_funcs.py
+++ b/src/teehr/metrics/bootstrap_funcs.py
@@ -381,6 +381,14 @@ def create_circularblock_func(model: MetricsBasemodel) -> Callable:
 
     If ``model.bootstrap.block_size`` is ``None``, the block size is estimated
     using ``arch.bootstrap.optimal_block_length`` (``b_cb`` column).
+
+    Not used by the aggregation pipeline. ``format.py`` routes every bootstrap
+    group -- including groups of one -- through
+    ``create_shared_bootstrap_func``, so this is retained as the public
+    ``Bootstrappers.*.func`` field default (frozen, see
+    ``models/bootstrap.py``), for the autodoc page, and as an independent
+    reference implementation the equivalence tests compare against. It has no
+    sample-size/mean/variance quality guards, unlike the shared path.
     """
     logger.debug("Building the Circular Block bootstrap func.")
 
@@ -422,7 +430,16 @@ def create_circularblock_func(model: MetricsBasemodel) -> Callable:
 
 
 def create_gumboot_func(model: MetricsBasemodel) -> Callable:
-    """Create the Gumboot bootstrap function."""
+    """Create the Gumboot bootstrap function.
+
+    Not used by the aggregation pipeline. ``format.py`` routes every bootstrap
+    group -- including groups of one -- through
+    ``create_shared_bootstrap_func``, so this is retained as the public
+    ``Bootstrappers.*.func`` field default (frozen, see
+    ``models/bootstrap.py``), for the autodoc page, and as an independent
+    reference implementation the equivalence tests compare against. It has no
+    sample-size/mean/variance quality guards, unlike the shared path.
+    """
     logger.debug("Building the Gumboot bootstrap func.")
 
     # lazy import to improve performance
@@ -463,6 +480,14 @@ def create_stationary_func(model: MetricsBasemodel) -> Callable:
 
     If ``model.bootstrap.block_size`` is ``None``, the block size is estimated
     using ``arch.bootstrap.optimal_block_length`` (``b_sb`` column).
+
+    Not used by the aggregation pipeline. ``format.py`` routes every bootstrap
+    group -- including groups of one -- through
+    ``create_shared_bootstrap_func``, so this is retained as the public
+    ``Bootstrappers.*.func`` field default (frozen, see
+    ``models/bootstrap.py``), for the autodoc page, and as an independent
+    reference implementation the equivalence tests compare against. It has no
+    sample-size/mean/variance quality guards, unlike the shared path.
     """
     logger.debug("Building the Stationary bootstrap func.")
 

--- a/src/teehr/metrics/bootstrap_funcs.py
+++ b/src/teehr/metrics/bootstrap_funcs.py
@@ -17,13 +17,32 @@ from teehr.querying.utils import bootstrap_quantile_key, parse_fields_to_list
 
 logger = logging.getLogger(__name__)
 
-# Internal rollout switch for the vectorized shared-bootstrap path -- not a
-# public/documented config option. Defaults to the legacy per-rep loop.
-# Set TEEHR_BOOTSTRAP_ENGINE=vectorized to opt in during validation. Read
-# dynamically (not cached at import time) so it can be toggled at runtime
-# (e.g. before creating a Spark session) and in tests via monkeypatch.
+# Engine selector for the shared-bootstrap path. The vectorized engine is now
+# the default; set TEEHR_BOOTSTRAP_ENGINE=legacy to fall back to the per-rep
+# loop. The escape hatch exists because the two are meant to be numerically
+# identical -- if they ever are not, switching back should be one env var, not
+# a release.
+#
+# Read dynamically (not cached at import time) so it can be toggled at runtime
+# (e.g. before creating a Spark session) and in tests via monkeypatch. On a
+# Spark cluster it must be set on the EXECUTORS, not just the driver --
+# spark.executorEnv.TEEHR_BOOTSTRAP_ENGINE -- since the check runs inside the
+# pandas UDF.
 def _vectorized_engine_enabled() -> bool:
-    return os.environ.get("TEEHR_BOOTSTRAP_ENGINE", "legacy").strip().lower() == "vectorized"
+    engine = os.environ.get("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
+    engine = engine.strip().lower()
+    if engine not in ("vectorized", "legacy"):
+        # Don't silently pick an engine for a typo. Which way a misspelling
+        # falls is invisible in the results -- the two engines agree
+        # numerically -- so the only symptom would be an unexplained 8x
+        # slowdown, or none at all.
+        logger.warning(
+            "Unrecognized TEEHR_BOOTSTRAP_ENGINE=%r; expected 'vectorized' "
+            "or 'legacy'. Using the default (vectorized).",
+            engine,
+        )
+        return True
+    return engine == "vectorized"
 
 
 def _vectorized_engine_available(ref_boot, metrics) -> bool:

--- a/src/teehr/metrics/deterministic_funcs.py
+++ b/src/teehr/metrics/deterministic_funcs.py
@@ -90,33 +90,35 @@ def _transform(
     else:
         logger.debug("No transform specified, using original values")
 
-    # Remove invalid values and align series if transform applied
-    if model.transform is not None:
-        logger.debug("Removing invalid values and aligning series")
-        if (t is not None) and (threshold_series is not None):
-            valid_mask = np.isfinite(p) & np.isfinite(s)
-            p = p[valid_mask]
-            s = s[valid_mask]
-            t = t[valid_mask]
-            threshold_series = threshold_series[valid_mask]
-        elif t is not None:
-            valid_mask = np.isfinite(p) & np.isfinite(s)
-            p = p[valid_mask]
-            s = s[valid_mask]
-            t = t[valid_mask]
-        elif threshold_series is not None:
-            valid_mask = np.isfinite(p) & np.isfinite(s)
-            p = p[valid_mask]
-            s = s[valid_mask]
-            threshold_series = threshold_series[valid_mask]
-        else:
-            valid_mask = np.isfinite(p) & np.isfinite(s)
-            p = p[valid_mask]
-            s = s[valid_mask]
-        logger.debug(
-            f"Removed {len(valid_mask) - np.sum(valid_mask)} invalid entries"
-            " from the transformed input series"
-            )
+    # Remove invalid values and align series.
+    #
+    # This runs UNCONDITIONALLY, not only when a transform was applied. It used
+    # to be gated on `model.transform is not None`, which made this the only
+    # metric path in teehr that kept non-finite pairs:
+    #
+    #   - signature_funcs._transform drops unconditionally
+    #   - spark_native filters `p.isNotNull() & s.isNotNull()` before it
+    #     aggregates
+    #
+    # Worse, what "keeping" them meant depended on which numpy call a closure
+    # happened to make, because the closures receive pd.Series:
+    # np.sum/mean/std/var/min/max dispatch to the *pandas* method and silently
+    # SKIP NaN, while np.median/np.cov/np.corrcoef take the numpy array path
+    # and PROPAGATE it. So relative_mean ignored a gap while
+    # pearson_correlation returned NaN for the same input, and `len(p)` in
+    # _mean_error counted rows the reduction above it had just skipped.
+    logger.debug("Removing invalid values and aligning series")
+    valid_mask = np.isfinite(p) & np.isfinite(s)
+    p = p[valid_mask]
+    s = s[valid_mask]
+    if t is not None:
+        t = t[valid_mask]
+    if threshold_series is not None:
+        threshold_series = threshold_series[valid_mask]
+    logger.debug(
+        f"Removed {len(valid_mask) - np.sum(valid_mask)} invalid entries"
+        " from the input series"
+        )
 
     # return results
     if (t is not None) and (threshold_series is not None):
@@ -325,8 +327,17 @@ def pearson_correlation(model: MetricsBasemodel) -> Callable:
         p, s = _transform(p, s, model)
 
         if model.add_epsilon:
-            # Calculate covariance between p and s
-            numerator = np.cov(p, s)[0, 1]
+            # ddof=0 (population covariance), to match the ddof=0 standard
+            # deviations below. np.cov defaults to ddof=1, and that mismatch
+            # does NOT cancel: cov/(n-1) over sqrt(SS/n) terms yields
+            # r * n/(n-1), which exceeds 1.0 for well-correlated data on small
+            # samples (r=1.110 at n=10) -- not a correlation at all.
+            #
+            # With consistent ddof this branch now differs from the np.corrcoef
+            # branch below ONLY by the +EPSILON divide-by-zero guard, which is
+            # all add_epsilon is meant to change. It also matches spark_native,
+            # which already pairs F.covar_pop with F.stddev_pop.
+            numerator = np.cov(p, s, ddof=0)[0, 1]
 
             # Calculate standard deviations and multiply them
             denominator = np.nanstd(p) * np.nanstd(s) + EPSILON
@@ -374,8 +385,10 @@ def r_squared(model: MetricsBasemodel) -> Callable:
         p, s = _transform(p, s, model)
 
         if model.add_epsilon:
-            # Calculate covariance between p and s
-            numerator = np.cov(p, s)[0, 1]
+            # ddof=0 to match the standard deviations below -- see the note in
+            # pearson_correlation. It compounds here: r^2 was inflated by
+            # (n/(n-1))^2, ~6.9% at n=30.
+            numerator = np.cov(p, s, ddof=0)[0, 1]
 
             # Calculate standard deviations and multiply them
             denominator = np.nanstd(p) * np.nanstd(s) + EPSILON

--- a/src/teehr/metrics/format.py
+++ b/src/teehr/metrics/format.py
@@ -57,9 +57,6 @@ def _build_non_bootstrap_udf(model: MetricsBasemodel, gp: GroupedData):
 def _build_shared_bootstrap_udfs(
     boot_groups,
     gp: GroupedData,
-    minimum_sample_size: int = 30,
-    minimum_mean: float = 0.01,
-    minimum_variance: float = 0.000025,
 ):
     """Return (func_list_entries, expansion_steps) for shared-bootstrap groups.
 
@@ -69,14 +66,6 @@ def _build_shared_bootstrap_udfs(
         Mapping of key → list of metrics sharing the same bootstrap config.
     gp : GroupedData
         The grouped Spark DataFrame (used for field validation).
-    minimum_sample_size : int, optional
-        Minimum sample count to run bootstrap. Default 30.
-    minimum_mean : float, optional
-        Minimum mean value of the primary series to run bootstrap. Default
-        0.01.
-    minimum_variance : float, optional
-        Minimum variance of the primary series to run bootstrap. Default
-        0.000025.
 
     Returns
     -------
@@ -127,18 +116,14 @@ def _build_shared_bootstrap_udfs(
         # a lone bootstrapped metric got no benefit from it at all. Routing
         # them here also gives them the sample-size/mean/variance quality
         # guards in create_shared_bootstrap_func, which previously applied only
-        # once a group had two or more metrics.
+        # once a group had two or more metrics. Those guards are configured on
+        # the Bootstrappers model, so nothing needs threading through here.
         temp_col = f"_bsgrp_{idx}"
         while temp_col in existing_columns:
             temp_col = f"_{temp_col}"
         existing_columns.add(temp_col)
 
-        shared_func = create_shared_bootstrap_func(
-            group_metrics,
-            minimum_sample_size=minimum_sample_size,
-            minimum_mean=minimum_mean,
-            minimum_variance=minimum_variance,
-        )
+        shared_func = create_shared_bootstrap_func(group_metrics)
         if boot.quantiles is None:
             return_type = T.MapType(
                 T.StringType(),

--- a/src/teehr/metrics/format.py
+++ b/src/teehr/metrics/format.py
@@ -22,7 +22,15 @@ logger = logging.getLogger(__name__)
 
 
 def _build_non_bootstrap_udf(model: MetricsBasemodel, gp: GroupedData):
-    """Return (udf_col_expr, alias) for a non-bootstrap or raw-array metric."""
+    """Return the aggregation column expression for a non-bootstrap metric.
+
+    Only ever called with ``partition_metrics_by_bootstrap``'s ``no_boot``
+    list, and ``bootstrap_group_key`` returns None only when ``bootstrap`` is
+    falsy -- so every model reaching here has no bootstrap config. This used to
+    carry a ``model.bootstrap is not None`` branch for a "raw array path"; it
+    was unreachable, and it was the only other consumer of ``boot.func`` /
+    ``boot.return_type``.
+    """
     if hasattr(model, "get_input_field_names"):
         input_field_names = parse_fields_to_list(model.get_input_field_names())
     else:
@@ -40,20 +48,8 @@ def _build_non_bootstrap_udf(model: MetricsBasemodel, gp: GroupedData):
 
     alias = model.output_field_name
 
-    if "bootstrap" in model.model_dump() and model.bootstrap is not None:
-        logger.debug(
-            f"Applying metric: {alias} with {model.bootstrap.name}"
-            " bootstrapping (raw array path)"
-        )
-        func_pd = pandas_udf(
-            model.bootstrap.func(model),
-            model.bootstrap.return_type
-        )
-        if model.bootstrap.include_value_time and "value_time" not in input_field_names:
-            input_field_names.append("value_time")
-    else:
-        logger.debug(f"Applying metric: {alias}")
-        func_pd = pandas_udf(model.func(model), model.return_type)
+    logger.debug(f"Applying metric: {alias}")
+    func_pd = pandas_udf(model.func(model), model.return_type)
 
     return func_pd(*input_field_names).alias(alias)
 
@@ -61,6 +57,9 @@ def _build_non_bootstrap_udf(model: MetricsBasemodel, gp: GroupedData):
 def _build_shared_bootstrap_udfs(
     boot_groups,
     gp: GroupedData,
+    minimum_sample_size: int = 30,
+    minimum_mean: float = 0.01,
+    minimum_variance: float = 0.000025,
 ):
     """Return (func_list_entries, expansion_steps) for shared-bootstrap groups.
 
@@ -70,6 +69,14 @@ def _build_shared_bootstrap_udfs(
         Mapping of key → list of metrics sharing the same bootstrap config.
     gp : GroupedData
         The grouped Spark DataFrame (used for field validation).
+    minimum_sample_size : int, optional
+        Minimum sample count to run bootstrap. Default 30.
+    minimum_mean : float, optional
+        Minimum mean value of the primary series to run bootstrap. Default
+        0.01.
+    minimum_variance : float, optional
+        Minimum variance of the primary series to run bootstrap. Default
+        0.000025.
 
     Returns
     -------
@@ -81,6 +88,7 @@ def _build_shared_bootstrap_udfs(
     """
     func_list = []
     expansions = []
+    existing_columns = set(gp._df.columns)
 
     for idx, (key, group_metrics) in enumerate(boot_groups.items()):
         ref = group_metrics[0]
@@ -91,42 +99,56 @@ def _build_shared_bootstrap_udfs(
         else:
             input_field_names = parse_fields_to_list(ref.input_field_names)
 
+        # Same check _build_non_bootstrap_udf runs. Without it a bootstrapped
+        # threshold metric with threshold_field_name=None fails inside the UDF
+        # with an opaque TypeError instead of this explicit error.
+        if ref.attrs["requires_threshold_field"]:
+            if ref.threshold_field_name is None:
+                raise ValueError(
+                    f"{ref} requires a valid threshold_field_name argument."
+                )
+            if ref.threshold_field_name not in input_field_names:
+                input_field_names.append(ref.threshold_field_name)
+
         if boot.include_value_time and "value_time" not in input_field_names:
             input_field_names.append("value_time")
 
         validate_fields_exist(gp._df.columns, input_field_names)
 
-        if len(group_metrics) == 1:
-            # Singleton — use the standard path but still via shared helper
-            # to keep the code uniform; it's the same cost as the old path.
-            logger.debug(
-                f"Applying metric: {ref.output_field_name} with "
-                f"{boot.name} bootstrapping"
+        names = [m.output_field_name for m in group_metrics]
+        logger.debug(
+            f"Applying {len(group_metrics)} metric(s) sharing {boot.name} "
+            f"bootstrap samples: {names}"
+        )
+
+        # Every group takes this path, including groups of one. Singletons used
+        # to be special-cased through boot.func(ref) -- i.e. the legacy
+        # per-replicate loop -- which never consulted the vectorized engine, so
+        # a lone bootstrapped metric got no benefit from it at all. Routing
+        # them here also gives them the sample-size/mean/variance quality
+        # guards in create_shared_bootstrap_func, which previously applied only
+        # once a group had two or more metrics.
+        temp_col = f"_bsgrp_{idx}"
+        while temp_col in existing_columns:
+            temp_col = f"_{temp_col}"
+        existing_columns.add(temp_col)
+
+        shared_func = create_shared_bootstrap_func(
+            group_metrics,
+            minimum_sample_size=minimum_sample_size,
+            minimum_mean=minimum_mean,
+            minimum_variance=minimum_variance,
+        )
+        if boot.quantiles is None:
+            return_type = T.MapType(
+                T.StringType(),
+                T.ArrayType(T.FloatType()),
             )
-            func_pd = pandas_udf(
-                boot.func(ref),
-                boot.return_type,
-            )
-            func_list.append(func_pd(*input_field_names).alias(ref.output_field_name))
-            # No expansion needed — MapType column already has the right name.
         else:
-            names = [m.output_field_name for m in group_metrics]
-            logger.debug(
-                f"Applying {len(group_metrics)} metrics sharing {boot.name} "
-                f"bootstrap samples: {names}"
-            )
-            temp_col = f"_bsgrp_{idx}"
-            shared_func = create_shared_bootstrap_func(group_metrics)
-            if boot.quantiles is None:
-                return_type = T.MapType(
-                    T.StringType(),
-                    T.ArrayType(T.FloatType()),
-                )
-            else:
-                return_type = T.MapType(T.StringType(), T.FloatType())
-            func_pd = pandas_udf(shared_func, return_type)
-            func_list.append(func_pd(*input_field_names).alias(temp_col))
-            expansions.append((temp_col, group_metrics))
+            return_type = T.MapType(T.StringType(), T.FloatType())
+        func_pd = pandas_udf(shared_func, return_type)
+        func_list.append(func_pd(*input_field_names).alias(temp_col))
+        expansions.append((temp_col, group_metrics))
 
     return func_list, expansions
 
@@ -150,9 +172,16 @@ def _materialize_shared_bootstrap_columns(sdf, expansions):
             if quantiles is None:
                 sdf = sdf.withColumn(name, F.col(temp_col).getItem(name))
             else:
+                # Dedupe exactly as derive_map_key_list does. A repeated
+                # quantile (e.g. [0.5, 0.50]) collapses to one entry in the
+                # dict the UDF returns, but F.create_map would emit the key
+                # twice and Spark's default mapKeyDedupPolicy=EXCEPTION then
+                # raises DUPLICATED_MAP_KEY at collect time.
+                keys = list(dict.fromkeys(
+                    bootstrap_quantile_key(name, q) for q in quantiles
+                ))
                 key_value_pairs = []
-                for q in quantiles:
-                    key = bootstrap_quantile_key(name, q)
+                for key in keys:
                     key_value_pairs.extend([
                         F.lit(key),
                         F.col(temp_col).getItem(key),

--- a/src/teehr/metrics/metric_attributes.py
+++ b/src/teehr/metrics/metric_attributes.py
@@ -121,7 +121,9 @@ PEARSON_ATTRS = {
 
 VR_ATTRS = {
     "short_name": "VR",
-    "display_name": "Variance Ratio",
+    # "Variability Ratio", not "Variance Ratio": the formula is a ratio of
+    # standard deviations (sigma_sec / sigma_prim), matching the user guide.
+    "display_name": "Variability Ratio",
     "category": mc.Deterministic,
     "value_range": [0.0, None],
     "optimal_value": 1.0,

--- a/src/teehr/metrics/models/base.py
+++ b/src/teehr/metrics/models/base.py
@@ -130,6 +130,34 @@ class BootstrapBasemodel(PydanticBaseModel):
     func : Callable
         The wrapper to generate the bootstrapping function,
         by default None.
+    minimum_sample_size : int
+        Minimum number of values in a group before it is bootstrapped, by
+        default 30. Groups below this return null rather than an interval.
+    minimum_mean : float
+        Minimum mean of the primary series before a group is bootstrapped, by
+        default 0.01.
+    minimum_variance : float
+        Minimum variance of the primary series before a group is
+        bootstrapped, by default 0.000025.
+
+    Notes
+    -----
+    The three ``minimum_*`` fields are quality guards: a stationary bootstrap
+    over eight points, or over a series that is effectively constant, yields
+    an interval that looks authoritative and means nothing. A group failing
+    any of them returns null for every metric sharing the config.
+
+    They live here, rather than on the aggregation call, because they are
+    properties of a bootstrap configuration -- and because metric grouping
+    already works that way: ``bootstrap_funcs.bootstrap_group_key`` keys
+    groups on the bootstrap config, so metrics sharing a config necessarily
+    share guards.
+
+    The defaults are uniform across methods. Note that for ``Gumboot`` the
+    scientifically meaningful sample size is the number of water years rather
+    than the number of timesteps, while the guard (like the others) measures
+    the input series length -- so a caller resampling few water years may want
+    to raise ``minimum_sample_size`` explicitly.
     """
 
     return_type: Union[str, T.ArrayType, T.MapType] = Field(default=None)
@@ -139,6 +167,9 @@ class BootstrapBasemodel(PydanticBaseModel):
     name: str = Field(default=None)
     include_value_time: bool = Field(default=False)
     func: Callable = Field(default=None)
+    minimum_sample_size: int = Field(default=30, ge=0)
+    minimum_mean: float = Field(default=0.01)
+    minimum_variance: float = Field(default=0.000025)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/src/teehr/metrics/models/base.py
+++ b/src/teehr/metrics/models/base.py
@@ -273,6 +273,50 @@ class DeterministicBasemodel(MetricsBasemodel):
             self.input_field_names = fields
         return self
 
+    @model_validator(mode="after")
+    def reject_bootstrap_on_value_time_metrics(self):
+        """Refuse to bootstrap a metric that depends on ``value_time``.
+
+        Resampling destroys the time axis these metrics are defined on. A
+        stationary or circular-block draw concatenates blocks in a new order
+        and repeats some of them, so "the time of the peak", "the difference
+        between the two peak times" or "the centre of timing" are computed
+        over a series whose timestamps no longer correspond to the values
+        beside them. The answer is not merely imprecise, it is undefined.
+
+        The combination did not work before this guard either -- it just
+        failed inconsistently. Measured across the five affected metrics:
+
+            metric                      Stationary       Gumboot
+            MaxValueTimeDelta           AttributeError   TypeError
+            MaxValueTime                TypeError        TypeError
+            AnnualPeakRelativeBias      "succeeded"      TypeError
+            CenterOfTiming              "succeeded"      TypeError
+            StandardDeviationOfTiming   "succeeded"      TypeError
+
+        Three of them returned numbers computed on a scrambled time axis,
+        which is worse than crashing. Under Gumboot all five raise, because
+        ``_make_bs_object`` peels the trailing ``value_time`` argument off for
+        its own water-year blocking and never forwards it to the metric.
+
+        That last point is why Gumboot is not carved out as an exception here
+        even though water-year resampling *does* preserve within-year time
+        structure: supporting it needs ``value_time`` plumbed through to the
+        closure and the resampled timestamps reconstructed, which is a feature
+        rather than a guard. See the note in the changelog.
+        """
+        if getattr(self, "bootstrap", None) is None:
+            return self
+        if self.value_time_field_name is None:
+            return self
+        raise ValueError(
+            f"{type(self).__name__} depends on "
+            f"'{self.value_time_field_name}' and cannot be bootstrapped: "
+            "resampling reorders and repeats observations, so the time axis "
+            "the metric is defined on no longer matches its values. Request "
+            "this metric without a bootstrap config."
+        )
+
     def get_input_field_names(self) -> List[Union[str, StrEnum]]:
         """Return concrete ordered input field names for downstream calls."""
         if self.input_field_names is None:

--- a/src/teehr/metrics/models/deterministic.py
+++ b/src/teehr/metrics/models/deterministic.py
@@ -441,6 +441,7 @@ class DeterministicMetrics:
     RelativeMinimum = RelativeMinimum
     RelativeMaximum = RelativeMaximum
     RelativeStandardDeviation = RelativeStandardDeviation
+    VariabilityRatio = VariabilityRatio
 
     # Correlation metrics
     PearsonCorrelation = PearsonCorrelation

--- a/src/teehr/metrics/vectorized_bootstrap_funcs.py
+++ b/src/teehr/metrics/vectorized_bootstrap_funcs.py
@@ -542,6 +542,10 @@ VECTORIZED_METRIC_FUNCS = {
     "MeanAbsoluteRelativeError": _vec_mean_absolute_relative_error,
     # multiplicative_bias_inner and relative_mean_inner are the same formula.
     "MultiplicativeBias": _vec_relative_mean,
+    # Likewise variability_ratio_inner and relative_standard_deviation_inner.
+    # Tracked separately as a duplicate-metric question; registering the
+    # kernel keeps the two from diverging in the meantime.
+    "VariabilityRatio": _vec_relative_standard_deviation,
     "Rsquared": _vec_r_squared,
     "NormalizedNashSutcliffeEfficiency": (
         _vec_nash_sutcliffe_efficiency_normalized

--- a/src/teehr/metrics/vectorized_bootstrap_funcs.py
+++ b/src/teehr/metrics/vectorized_bootstrap_funcs.py
@@ -31,11 +31,10 @@ Coverage is intentionally narrow and explicit:
   metrics never silently produces wrong numbers for unvectorized ones.
 
 Every kernel here mirrors the corresponding scalar closure in
-``deterministic_funcs.py`` formula-for-formula, including quirks (e.g.
-``pearson_correlation``'s ``add_epsilon`` branch mixes ``np.cov`` (ddof=1)
-with ``np.std``/``nanstd`` (ddof=0) -- that mismatch is preserved exactly,
-not "fixed", since the goal is behavioral equivalence with the existing
-implementation, not a cleaner formula).
+``deterministic_funcs.py`` formula-for-formula. Behavioral equivalence with the
+scalar path is the contract, so a kernel is never "improved" relative to its
+closure; where a formula genuinely needed correcting, both sides were changed
+together (see ``_vec_pearson_r`` on the ddof mismatch).
 """
 from typing import Any, Dict, List
 
@@ -77,42 +76,51 @@ def _vectorized_transform(
     uses NaN-aware reductions (``nanmean``/``nanstd``/``nanmedian``/
     ``nansum``), so masking is mathematically equivalent to the legacy
     per-replicate drop-then-compute behavior for all metrics covered here.
+
+    The mask is **pairwise and unconditional**, mirroring
+    ``deterministic_funcs._transform``. Both properties matter:
+
+    - *Pairwise*, because the scalar path drops a whole row when either series
+      is non-finite there. Masking only each series' own NaNs would let
+      ``nanmean(p)`` and ``nanmean(s)`` reduce over different subsets, so e.g.
+      ``relative_mean`` would divide two means computed from different rows.
+    - *Unconditional*, because the scalar drop is no longer gated on a
+      transform being set (it used to be, which is what made the two paths
+      disagree on gappy data).
     """
     transform = getattr(model, "transform", None)
-    if transform is None:
-        return p, s
-
     add_epsilon = getattr(model, "add_epsilon", False)
 
-    if transform == TransformEnum.log:
-        if add_epsilon:
-            p = p + EPSILON
-            s = s + EPSILON
-        p = np.log(p)
-        s = np.log(s)
-    elif transform == TransformEnum.sqrt:
-        p = np.sqrt(p)
-        s = np.sqrt(s)
-    elif transform == TransformEnum.square:
-        p = np.square(p)
-        s = np.square(s)
-    elif transform == TransformEnum.cube:
-        p = np.power(p, 3)
-        s = np.power(s, 3)
-    elif transform == TransformEnum.exp:
-        p = np.exp(p)
-        s = np.exp(s)
-    elif transform == TransformEnum.inv:
-        if add_epsilon:
-            p = p + EPSILON
-            s = s + EPSILON
-        p = 1.0 / p
-        s = 1.0 / s
-    elif transform == TransformEnum.abs:
-        p = np.abs(p)
-        s = np.abs(s)
-    else:
-        raise ValueError(f"Unsupported transform: {transform}")
+    if transform is not None:
+        if transform == TransformEnum.log:
+            if add_epsilon:
+                p = p + EPSILON
+                s = s + EPSILON
+            p = np.log(p)
+            s = np.log(s)
+        elif transform == TransformEnum.sqrt:
+            p = np.sqrt(p)
+            s = np.sqrt(s)
+        elif transform == TransformEnum.square:
+            p = np.square(p)
+            s = np.square(s)
+        elif transform == TransformEnum.cube:
+            p = np.power(p, 3)
+            s = np.power(s, 3)
+        elif transform == TransformEnum.exp:
+            p = np.exp(p)
+            s = np.exp(s)
+        elif transform == TransformEnum.inv:
+            if add_epsilon:
+                p = p + EPSILON
+                s = s + EPSILON
+            p = 1.0 / p
+            s = 1.0 / s
+        elif transform == TransformEnum.abs:
+            p = np.abs(p)
+            s = np.abs(s)
+        else:
+            raise ValueError(f"Unsupported transform: {transform}")
 
     invalid = ~(np.isfinite(p) & np.isfinite(s))
     if np.any(invalid):
@@ -125,10 +133,16 @@ def _vectorized_transform(
 def _vec_pearson_r(p: np.ndarray, s: np.ndarray, add_epsilon: bool) -> np.ndarray:
     """Row-wise Pearson correlation, matching ``pearson_correlation_inner``.
 
-    ``add_epsilon=False`` mirrors ``np.corrcoef(s, p)[0][1]`` (a single
-    consistent-ddof formula). ``add_epsilon=True`` mirrors
-    ``np.cov(p, s)[0, 1] / (nanstd(p) * nanstd(s) + EPSILON)`` -- note the
-    ddof=1 (cov) vs ddof=0 (std) mismatch is intentional, preserved as-is.
+    ``add_epsilon=False`` mirrors ``np.corrcoef(s, p)[0][1]``.
+    ``add_epsilon=True`` mirrors
+    ``np.cov(p, s, ddof=0)[0, 1] / (nanstd(p) * nanstd(s) + EPSILON)``.
+
+    Both branches use a consistent ddof=0, so the two differ only by the
+    ``+EPSILON`` divide-by-zero guard. An earlier version paired ``np.cov``'s
+    default ddof=1 with ddof=0 standard deviations; those do not cancel and the
+    result was ``r * n/(n-1)``, which exceeds 1.0 on small well-correlated
+    samples. The mismatch was documented as intentional but produced a quantity
+    that is not a correlation coefficient.
     """
     n = np.sum(np.isfinite(p) & np.isfinite(s), axis=1)
     p_mean = np.nanmean(p, axis=1, keepdims=True)
@@ -139,8 +153,9 @@ def _vec_pearson_r(p: np.ndarray, s: np.ndarray, add_epsilon: bool) -> np.ndarra
 
     with np.errstate(invalid="ignore", divide="ignore"):
         if add_epsilon:
-            # np.cov default ddof=1 (sample covariance).
-            cov = cov_sum / np.maximum(n - 1, 1)
+            # ddof=0 (population covariance), matching np.cov(..., ddof=0) and
+            # the ddof=0 nanstd denominator below.
+            cov = cov_sum / np.maximum(n, 1)
             denom = np.nanstd(p, axis=1) * np.nanstd(s, axis=1) + EPSILON
             return cov / denom
         else:

--- a/src/teehr/metrics/vectorized_bootstrap_funcs.py
+++ b/src/teehr/metrics/vectorized_bootstrap_funcs.py
@@ -74,6 +74,37 @@ def build_index_matrix(bs: Any, reps: int) -> np.ndarray:
     return np.stack([np.asarray(bs.update_indices()) for _ in range(reps)])
 
 
+def _apply_transform_1d(
+    x: np.ndarray,
+    transform: TransformEnum,
+    add_epsilon: bool,
+) -> np.ndarray:
+    """Apply one transform to one matrix, mirroring the scalar ``match`` block.
+
+    Shared by the two-field and single-field transforms so the branch list
+    cannot drift between them. Never mutates ``x``.
+    """
+    if transform == TransformEnum.log:
+        if add_epsilon:
+            x = x + EPSILON
+        return np.log(x)
+    elif transform == TransformEnum.sqrt:
+        return np.sqrt(x)
+    elif transform == TransformEnum.square:
+        return np.square(x)
+    elif transform == TransformEnum.cube:
+        return np.power(x, 3)
+    elif transform == TransformEnum.exp:
+        return np.exp(x)
+    elif transform == TransformEnum.inv:
+        if add_epsilon:
+            x = x + EPSILON
+        return 1.0 / x
+    elif transform == TransformEnum.abs:
+        return np.abs(x)
+    raise ValueError(f"Unsupported transform: {transform}")
+
+
 def _vectorized_transform(
     p: np.ndarray,
     s: np.ndarray,
@@ -102,35 +133,8 @@ def _vectorized_transform(
     add_epsilon = getattr(model, "add_epsilon", False)
 
     if transform is not None:
-        if transform == TransformEnum.log:
-            if add_epsilon:
-                p = p + EPSILON
-                s = s + EPSILON
-            p = np.log(p)
-            s = np.log(s)
-        elif transform == TransformEnum.sqrt:
-            p = np.sqrt(p)
-            s = np.sqrt(s)
-        elif transform == TransformEnum.square:
-            p = np.square(p)
-            s = np.square(s)
-        elif transform == TransformEnum.cube:
-            p = np.power(p, 3)
-            s = np.power(s, 3)
-        elif transform == TransformEnum.exp:
-            p = np.exp(p)
-            s = np.exp(s)
-        elif transform == TransformEnum.inv:
-            if add_epsilon:
-                p = p + EPSILON
-                s = s + EPSILON
-            p = 1.0 / p
-            s = 1.0 / s
-        elif transform == TransformEnum.abs:
-            p = np.abs(p)
-            s = np.abs(s)
-        else:
-            raise ValueError(f"Unsupported transform: {transform}")
+        p = _apply_transform_1d(p, transform, add_epsilon)
+        s = _apply_transform_1d(s, transform, add_epsilon)
 
     invalid = ~(np.isfinite(p) & np.isfinite(s))
     if np.any(invalid):
@@ -138,6 +142,45 @@ def _vectorized_transform(
         s = np.where(invalid, np.nan, s)
 
     return p, s
+
+
+def _vectorized_signature_transform(
+    p: np.ndarray,
+    model: MetricsBasemodel,
+) -> np.ndarray:
+    """Row-wise equivalent of ``signature_funcs._transform``.
+
+    Signature metrics are single-field, so the mask depends on ``p`` alone --
+    that is the only difference from ``_vectorized_transform``, which masks
+    pairwise. Masking non-finite values is required rather than optional: the
+    scalar path drops them (``signature_funcs._transform``), so leaving an inf
+    in place would let ``nansum``/``nanmax`` see a value the scalar path never
+    does.
+    """
+    transform = getattr(model, "transform", None)
+    if transform is not None:
+        p = _apply_transform_1d(
+            p, transform, getattr(model, "add_epsilon", False)
+        )
+
+    invalid = ~np.isfinite(p)
+    if np.any(invalid):
+        p = np.where(invalid, np.nan, p)
+
+    return p
+
+
+def _finite_pair_count(p: np.ndarray, s: np.ndarray) -> np.ndarray:
+    """Per-row count of positions finite in both series (or in ``p`` alone).
+
+    This is the row-wise equivalent of ``len(p)`` *after* ``_transform``, which
+    since the unconditional-drop fix is always the count of surviving pairs --
+    so metrics dividing by ``len(...)`` (the ``_mean_error`` family) need this
+    rather than the raw row width.
+    """
+    if s is None:
+        return np.sum(np.isfinite(p), axis=1)
+    return np.sum(np.isfinite(p) & np.isfinite(s), axis=1)
 
 
 def _vec_pearson_r(p: np.ndarray, s: np.ndarray, add_epsilon: bool) -> np.ndarray:
@@ -228,9 +271,14 @@ def _vec_relative_bias(p, s, model) -> np.ndarray:
     return diff_sum / p_sum
 
 
-def _vec_nash_sutcliffe_efficiency(p, s, model) -> np.ndarray:
+def _vec_nse_parts(p, s, model) -> tuple:
+    """Numerator, denominator and NaN guard shared by NSE and normalized NSE.
+
+    The two scalar closures are identical up to their final expression, so
+    sharing the parts keeps the guards from drifting apart.
+    """
     # Legacy guards (per-row, before transform): empty or all-zero-sum rows -> NaN.
-    n_valid = np.sum(np.isfinite(p) & np.isfinite(s), axis=1)
+    n_valid = _finite_pair_count(p, s)
     p_sum_raw = np.nansum(p, axis=1)
     s_sum_raw = np.nansum(s, axis=1)
     guard_nan = (n_valid == 0) | (p_sum_raw == 0) | (s_sum_raw == 0)
@@ -242,10 +290,24 @@ def _vec_nash_sutcliffe_efficiency(p, s, model) -> np.ndarray:
     if model.add_epsilon:
         denominator = denominator + EPSILON
 
+    return numerator, denominator, guard_nan | (denominator == 0)
+
+
+def _vec_nash_sutcliffe_efficiency(p, s, model) -> np.ndarray:
+    numerator, denominator, guard_nan = _vec_nse_parts(p, s, model)
     with np.errstate(invalid="ignore", divide="ignore"):
         result = 1.0 - numerator / denominator
-    result = np.where(guard_nan | (denominator == 0), np.nan, result)
-    return result
+    return np.where(guard_nan, np.nan, result)
+
+
+def _vec_nash_sutcliffe_efficiency_normalized(p, s, model) -> np.ndarray:
+    numerator, denominator, guard_nan = _vec_nse_parts(p, s, model)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        # Written as the scalar closure writes it (1/(1 + num/den)) rather than
+        # the algebraically equal 1/(2 - NSE): same value, but bit-identical to
+        # deterministic_funcs and no second division.
+        result = 1.0 / (1.0 + numerator / denominator)
+    return np.where(guard_nan, np.nan, result)
 
 
 def _vec_kling_gupta_efficiency(p, s, model) -> np.ndarray:
@@ -282,6 +344,184 @@ def _vec_pearson_correlation(p, s, model) -> np.ndarray:
     return _vec_pearson_r(p, s, add_epsilon=model.add_epsilon)
 
 
+def _vec_r_squared(p, s, model) -> np.ndarray:
+    # r_squared_inner is pearson_correlation_inner with the result squared.
+    p, s = _vectorized_transform(p, s, model)
+    return _vec_pearson_r(p, s, add_epsilon=model.add_epsilon) ** 2
+
+
+def _vec_mean_error_core(p, s, model, power=1.0, root=False) -> np.ndarray:
+    """Row-wise ``deterministic_funcs._mean_error`` on transformed matrices.
+
+    Takes ALREADY-transformed inputs, mirroring the scalar helper, which its
+    callers likewise invoke after ``_transform``.
+
+    The denominator is the finite-pair count, not the row width: the scalar
+    helper divides by ``len(y_true)`` *after* ``_transform`` has dropped
+    non-finite pairs.
+    """
+    with np.errstate(invalid="ignore", divide="ignore"):
+        me = (
+            np.nansum(np.abs(p - s) ** power, axis=1)
+            / _finite_pair_count(p, s)
+        )
+    return np.sqrt(me) if root else me
+
+
+def _vec_mean_error(p, s, model) -> np.ndarray:
+    # mean_error_inner uses np.sum(s - p)/len(p) directly, NOT _mean_error --
+    # note it is signed, and s - p rather than |p - s|.
+    p, s = _vectorized_transform(p, s, model)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return np.nansum(s - p, axis=1) / _finite_pair_count(p, s)
+
+
+def _vec_mean_absolute_error(p, s, model) -> np.ndarray:
+    p, s = _vectorized_transform(p, s, model)
+    return _vec_mean_error_core(p, s, model)
+
+
+def _vec_mean_squared_error(p, s, model) -> np.ndarray:
+    p, s = _vectorized_transform(p, s, model)
+    return _vec_mean_error_core(p, s, model, power=2.0)
+
+
+def _vec_root_mean_squared_error(p, s, model) -> np.ndarray:
+    p, s = _vectorized_transform(p, s, model)
+    return _vec_mean_error_core(p, s, model, power=2.0, root=True)
+
+
+def _vec_root_mean_standard_deviation_ratio(p, s, model) -> np.ndarray:
+    # Transforms ONCE then calls the core helper, mirroring
+    # root_mean_standard_deviation_ratio_inner calling _root_mean_squared_error
+    # (the helper that does no transform of its own). Delegating to
+    # _vec_root_mean_squared_error instead would transform twice.
+    p, s = _vectorized_transform(p, s, model)
+    rmse = _vec_mean_error_core(p, s, model, power=2.0, root=True)
+    p_std = np.nanstd(p, axis=1)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        if model.add_epsilon:
+            return rmse / (p_std + EPSILON)
+        return rmse / p_std
+
+
+def _vec_mean_absolute_relative_error(p, s, model) -> np.ndarray:
+    p, s = _vectorized_transform(p, s, model)
+    numerator = np.nansum(np.abs(s - p), axis=1)
+    p_sum = np.nansum(p, axis=1)          # np.sum(p): p only, not pairwise
+    with np.errstate(invalid="ignore", divide="ignore"):
+        if model.add_epsilon:
+            return numerator / (p_sum + EPSILON)
+        return numerator / p_sum
+
+
+def _vec_max_value_delta(p, s, model) -> np.ndarray:
+    p, s = _vectorized_transform(p, s, model)
+    return np.nanmax(s, axis=1) - np.nanmax(p, axis=1)
+
+
+def _vec_kling_gupta_efficiency_mod1(p, s, model) -> np.ndarray:
+    # Legacy guard (pre-transform): zero std on either side -> NaN.
+    guard_nan = (np.nanstd(s, axis=1) == 0) | (np.nanstd(p, axis=1) == 0)
+
+    p, s = _vectorized_transform(p, s, model)
+    r = _vec_pearson_r(p, s, add_epsilon=False)  # always plain corrcoef
+
+    p_std = np.nanstd(p, axis=1)
+    s_std = np.nanstd(s, axis=1)
+    p_mean = np.nanmean(p, axis=1)
+    s_mean = np.nanmean(s, axis=1)
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        if model.add_epsilon:
+            # Mod1's variability ratio is a ratio of coefficients of
+            # variation, unlike kge's ratio of raw standard deviations.
+            var_ratio = (
+                (s_std / (s_mean + EPSILON)) / (p_std / (p_mean + EPSILON))
+            )
+            rel_mean = s_mean / (p_mean + EPSILON)
+        else:
+            var_ratio = (s_std / s_mean) / (p_std / p_mean)
+            rel_mean = s_mean / p_mean
+
+    euclidean = np.sqrt(
+        model.sr * (r - 1.0) ** 2
+        + model.sa * (var_ratio - 1.0) ** 2
+        + model.sb * (rel_mean - 1.0) ** 2
+    )
+    return np.where(guard_nan, np.nan, 1.0 - euclidean)
+
+
+def _vec_kling_gupta_efficiency_mod2(p, s, model) -> np.ndarray:
+    # Legacy guard (pre-transform): zero std on either side -> NaN.
+    guard_nan = (np.nanstd(s, axis=1) == 0) | (np.nanstd(p, axis=1) == 0)
+
+    p, s = _vectorized_transform(p, s, model)
+    r = _vec_pearson_r(p, s, add_epsilon=False)  # always plain corrcoef
+
+    p_std = np.nanstd(p, axis=1)
+    s_std = np.nanstd(s, axis=1)
+    p_mean = np.nanmean(p, axis=1)
+    s_mean = np.nanmean(s, axis=1)
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        if model.add_epsilon:
+            rel_var = s_std / (p_std + EPSILON)
+            bias = ((s_mean - p_mean) ** 2) / ((p_std ** 2) + EPSILON)
+        else:
+            rel_var = s_std / p_std
+            bias = ((s_mean - p_mean) ** 2) / (p_std ** 2)
+
+    euclidean = np.sqrt(
+        model.sr * (r - 1.0) ** 2
+        + model.sa * (rel_var - 1.0) ** 2
+        + model.sb * bias          # NOT squared, unlike the other two terms
+    )
+    return np.where(guard_nan, np.nan, 1.0 - euclidean)
+
+
+# --- Signature kernels -----------------------------------------------------
+#
+# Single-field: `s` is None (see compute_vectorized_shared_bootstrap) and is
+# accepted only to keep one uniform kernel signature across the registry.
+# bootstrap_group_key includes the input-field tuple, so signature metrics form
+# their own groups and can never be mixed with two-field ones.
+
+def _vec_count(p, s, model) -> np.ndarray:
+    """Row-wise ``len(p)`` after the drop.
+
+    Near-degenerate under fixed-size resampling: every draw has the same
+    length, so this varies only with how many non-finite positions a draw
+    happens to hit. Registered anyway because the engine gate is per group --
+    leaving it out would drag a group like {Count, Average, Maximum} entirely
+    onto the per-replicate loop.
+    """
+    return _finite_pair_count(
+        _vectorized_signature_transform(p, model), None
+    ).astype(float)
+
+
+def _vec_minimum(p, s, model) -> np.ndarray:
+    return np.nanmin(_vectorized_signature_transform(p, model), axis=1)
+
+
+def _vec_maximum(p, s, model) -> np.ndarray:
+    return np.nanmax(_vectorized_signature_transform(p, model), axis=1)
+
+
+def _vec_average(p, s, model) -> np.ndarray:
+    return np.nanmean(_vectorized_signature_transform(p, model), axis=1)
+
+
+def _vec_sum(p, s, model) -> np.ndarray:
+    return np.nansum(_vectorized_signature_transform(p, model), axis=1)
+
+
+def _vec_variance(p, s, model) -> np.ndarray:
+    # np.var(Series) dispatches to pandas with ddof=0, so nanvar matches.
+    return np.nanvar(_vectorized_signature_transform(p, model), axis=1)
+
+
 # Registry: metric class name -> vectorized kernel(p_mat, s_mat, model) -> (reps,) array.
 VECTORIZED_METRIC_FUNCS = {
     "RelativeMean": _vec_relative_mean,
@@ -293,6 +533,29 @@ VECTORIZED_METRIC_FUNCS = {
     "NashSutcliffeEfficiency": _vec_nash_sutcliffe_efficiency,
     "KlingGuptaEfficiency": _vec_kling_gupta_efficiency,
     "PearsonCorrelation": _vec_pearson_correlation,
+    # --- Deterministic, row-wise reductions ---
+    "MeanError": _vec_mean_error,
+    "MeanAbsoluteError": _vec_mean_absolute_error,
+    "MeanSquareError": _vec_mean_squared_error,
+    "RootMeanSquareError": _vec_root_mean_squared_error,
+    "RootMeanStandardDeviationRatio": _vec_root_mean_standard_deviation_ratio,
+    "MeanAbsoluteRelativeError": _vec_mean_absolute_relative_error,
+    # multiplicative_bias_inner and relative_mean_inner are the same formula.
+    "MultiplicativeBias": _vec_relative_mean,
+    "Rsquared": _vec_r_squared,
+    "NormalizedNashSutcliffeEfficiency": (
+        _vec_nash_sutcliffe_efficiency_normalized
+    ),
+    "KlingGuptaEfficiencyMod1": _vec_kling_gupta_efficiency_mod1,
+    "KlingGuptaEfficiencyMod2": _vec_kling_gupta_efficiency_mod2,
+    "MaxValueDelta": _vec_max_value_delta,
+    # --- Signature (single-field; the kernel's `s` argument is None) ---
+    "Count": _vec_count,
+    "Minimum": _vec_minimum,
+    "Maximum": _vec_maximum,
+    "Average": _vec_average,
+    "Sum": _vec_sum,
+    "Variance": _vec_variance,
 }
 
 

--- a/src/teehr/metrics/vectorized_bootstrap_funcs.py
+++ b/src/teehr/metrics/vectorized_bootstrap_funcs.py
@@ -30,6 +30,15 @@ Coverage is intentionally narrow and explicit:
   to the legacy per-rep scalar closure for that metric only, so adding new
   metrics never silently produces wrong numbers for unvectorized ones.
 
+  This fallback really is per metric. It previously was not: the gate in
+  ``bootstrap_funcs`` used ``all(...)``, so a single uncovered metric pushed
+  its whole group onto the legacy loop -- measured at 78 ms/group for nine
+  covered metrics versus 638 ms/group for the same nine plus one uncovered
+  one. Since ``bootstrap_group_key`` deliberately excludes metric class,
+  heterogeneous groups are the norm, so that cliff was easy to hit. The
+  fallback shares one index matrix with the kernels, so a mixed group still
+  evaluates every metric on identical draws.
+
 Every kernel here mirrors the corresponding scalar closure in
 ``deterministic_funcs.py`` formula-for-formula. Behavioral equivalence with the
 scalar path is the contract, so a kernel is never "improved" relative to its
@@ -39,6 +48,7 @@ together (see ``_vec_pearson_r`` on the ddof mismatch).
 from typing import Any, Dict, List
 
 import numpy as np
+import pandas as pd
 
 from teehr.metrics.models.base import MetricsBasemodel, TransformEnum
 from teehr.querying.utils import bootstrap_quantile_key
@@ -286,32 +296,107 @@ VECTORIZED_METRIC_FUNCS = {
 }
 
 
+def is_vectorized_metric(metric: MetricsBasemodel) -> bool:
+    """Whether this metric has a vectorized kernel in the registry."""
+    return type(metric).__name__ in VECTORIZED_METRIC_FUNCS
+
+
+def resample_args(args: tuple, indices: np.ndarray) -> tuple:
+    """One replicate's args, as ``arch.IIDBootstrap._resample`` builds them.
+
+    pandas inputs are resampled with ``.iloc``, which **preserves the original
+    (now duplicated) index labels** -- verified against ``bs.apply`` to match
+    on values, index and type. Several scalar closures depend on pandas
+    semantics rather than plain arrays (``Series.idxmax`` in
+    ``deterministic_funcs.max_value_timedelta``, ``Series.sort_values`` in
+    ``signature_funcs.flow_duration_curve_slope``, and the boolean-mask
+    indexing in ``_transform``), so both the type and the index have to match
+    or the fallback would not be equivalent to the legacy path.
+    """
+    return tuple(
+        a.iloc[indices] if isinstance(a, (pd.Series, pd.DataFrame))
+        else np.asarray(a)[indices]
+        for a in args
+    )
+
+
+def assemble_bootstrap_output(
+    output_names: List[str],
+    values: np.ndarray,
+    quantiles,
+) -> Dict[str, Any]:
+    """Format a ``(reps, n_metrics)`` result matrix as the UDF's return dict.
+
+    Shared by the vectorized and legacy paths so the two cannot drift in the
+    keys or ordering they emit.
+
+    Parameters
+    ----------
+    output_names : list of str
+        One name per column of *values*.
+    values : np.ndarray
+        ``(reps, n_metrics)`` replicate results.
+    quantiles : list or None
+        Quantile-keyed floats when set; raw per-replicate lists when None.
+    """
+    combined: Dict[str, Any] = {}
+    for i, name in enumerate(output_names):
+        column = np.asarray(values[:, i], dtype=float)
+        if quantiles is None:
+            combined[name] = column.tolist()
+        else:
+            q_values = np.quantile(column, quantiles)
+            for q, v in zip(quantiles, q_values):
+                combined[bootstrap_quantile_key(name, q)] = v
+    return combined
+
+
 def compute_vectorized_shared_bootstrap(
     metrics: List[MetricsBasemodel],
+    metric_funcs: List[Any],
     args: tuple,
     bs: Any,
     reps: int,
     quantiles,
+    max_matrix_cells: int = 20_000_000,
 ) -> Dict[str, Any]:
     """Vectorized equivalent of the per-rep loop inside ``create_shared_bootstrap_func``.
+
+    Metrics **with** a kernel are evaluated by it on the whole ``(reps, n)``
+    batch; metrics **without** one fall back to their own scalar closure,
+    called once per replicate. Both consume the *same* index matrix, so every
+    metric in the group still sees identical draws -- which is the entire point
+    of a shared bootstrap. ``bs.apply`` is deliberately not called here, so
+    there is no second RNG consumer that could let the two subsets diverge.
 
     Parameters
     ----------
     metrics : list
-        Metrics sharing the same bootstrap config, all present in
-        ``VECTORIZED_METRIC_FUNCS`` (callers must check this beforehand).
+        Metrics sharing the same bootstrap config. At least one must have a
+        kernel (see ``bootstrap_funcs._can_use_vectorized_engine``); the rest
+        are handled by the fallback loop.
+    metric_funcs : list
+        The scalar closures for *metrics*, positionally aligned, built once at
+        UDF-creation time. Passed in rather than derived here so the closure
+        factories are not re-run for every Spark group.
     args : tuple
-        The (primary_value, secondary_value) series/arrays passed to the UDF,
-        in the same order used to build ``bs``.
+        The series passed to the UDF, in the same order used to build ``bs``.
+        ``args[0]`` is primary; ``args[1]``, when present, is secondary.
     bs : arch.bootstrap.IIDBootstrap subclass instance
-        Already-constructed bootstrap object (same as the legacy path's
-        ``_make_bs_object`` result) -- reused here purely for its
-        ``update_indices()`` method and RNG state.
+        Already-constructed bootstrap object (the same one the legacy path
+        would use) -- reused here purely for ``update_indices()`` and its RNG
+        state.
     reps : int
         Number of bootstrap replicates.
     quantiles : list or None
         If set, return per-metric quantile dict entries; if None, return
         raw per-replicate arrays (matching the legacy raw-array contract).
+    max_matrix_cells : int, optional
+        Cap on ``reps * n`` per batch. ``idx``, ``p_mat`` and ``s_mat`` are
+        each this size, so an uncapped call at large n would allocate three
+        big matrices inside a Spark executor, per concurrent task. Chunking is
+        bit-identical because ``build_index_matrix`` draws sequentially, so
+        chunk boundaries do not perturb the RNG stream.
 
     Returns
     -------
@@ -321,22 +406,41 @@ def compute_vectorized_shared_bootstrap(
         list of floats per metric name.
     """
     p_arr = np.asarray(args[0], dtype=float)
-    s_arr = np.asarray(args[1], dtype=float)
+    s_arr = np.asarray(args[1], dtype=float) if len(args) > 1 else None
+    n = p_arr.shape[0]
 
-    idx = build_index_matrix(bs, reps)  # (reps, n)
-    p_mat = p_arr[idx]
-    s_mat = s_arr[idx]
+    covered = [
+        (i, m, VECTORIZED_METRIC_FUNCS[type(m).__name__])
+        for i, m in enumerate(metrics)
+        if is_vectorized_metric(m)
+    ]
+    fallback = [
+        (i, metric_funcs[i])
+        for i, m in enumerate(metrics)
+        if not is_vectorized_metric(m)
+    ]
 
-    combined: Dict[str, Any] = {}
-    for metric in metrics:
-        kernel = VECTORIZED_METRIC_FUNCS[type(metric).__name__]
-        values = kernel(p_mat, s_mat, metric)
-        name = metric.output_field_name
-        if quantiles is None:
-            combined[name] = np.asarray(values, dtype=float).tolist()
-        else:
-            q_values = np.quantile(values, quantiles)
-            for q, v in zip(quantiles, q_values):
-                combined[bootstrap_quantile_key(name, q)] = v
+    # Mirrors arch's own np.zeros((reps, num_params)) result buffer.
+    values = np.empty((reps, len(metrics)), dtype=float)
+    chunk = max(1, min(reps, max_matrix_cells // max(n, 1)))
 
-    return combined
+    done = 0
+    while done < reps:
+        k = min(chunk, reps - done)
+        idx = build_index_matrix(bs, k)  # (k, n), same draw order as bs.apply
+        if covered:
+            p_mat = p_arr[idx]
+            s_mat = s_arr[idx] if s_arr is not None else None
+            for i, metric, kernel in covered:
+                values[done:done + k, i] = kernel(p_mat, s_mat, metric)
+        for r in range(k):
+            if not fallback:
+                break
+            draw = resample_args(args, idx[r])
+            for i, fn in fallback:
+                values[done + r, i] = fn(*draw)
+        done += k
+
+    return assemble_bootstrap_output(
+        [m.output_field_name for m in metrics], values, quantiles
+    )

--- a/tests/query/test_metrics_aggregate.py
+++ b/tests/query/test_metrics_aggregate.py
@@ -52,12 +52,17 @@ def test_executing_deterministic_metrics(function_scope_test_warehouse):
     assert metrics_df.equals(metrics_df2)
     assert isinstance(metrics_df, pd.DataFrame)
     assert metrics_df.index.size == 3
-    assert metrics_df.columns.size == 25
+    # 26 = 25 non-conditional deterministic metrics + the group_by column.
+    # Went from 25 when VariabilityRatio was registered in the
+    # DeterministicMetrics container; it was already implemented, documented,
+    # tested and Spark-native supported, just unreachable from the container.
+    assert metrics_df.columns.size == 26
     assert "relative_mean" in metrics_df.columns
     assert "relative_median" in metrics_df.columns
     assert "relative_minimum" in metrics_df.columns
     assert "relative_maximum" in metrics_df.columns
     assert "relative_standard_deviation" in metrics_df.columns
+    assert "variability_ratio" in metrics_df.columns
 
     # Test all the conditional metrics.
     include_conditional_metrics = [

--- a/tests/query/test_metrics_bootstrapping.py
+++ b/tests/query/test_metrics_bootstrapping.py
@@ -1035,6 +1035,54 @@ def test_singleton_group_is_routed_through_the_shared_path(
     ]
 
 
+@pytest.mark.parametrize("cls", [
+    DeterministicMetrics.MaxValueTimeDelta,
+    DeterministicMetrics.AnnualPeakRelativeBias,
+    Signatures.MaxValueTime,
+    Signatures.CenterOfTiming,
+    Signatures.StandardDeviationOfTiming,
+])
+def test_value_time_metrics_reject_bootstrap(cls):
+    """value_time-dependent metrics must refuse a bootstrap config.
+
+    Resampling reorders and repeats observations, so the time axis these are
+    defined on no longer lines up with the values beside it. The combination
+    never worked -- it failed inconsistently: MaxValueTimeDelta and
+    MaxValueTime raised, while AnnualPeakRelativeBias, CenterOfTiming and
+    StandardDeviationOfTiming returned numbers computed on a scrambled time
+    axis. Under Gumboot all five raised, because _make_bs_object peels the
+    trailing value_time argument off for water-year blocking and never
+    forwards it to the metric.
+    """
+    boot = Bootstrappers.Stationary(seed=1, reps=10, quantiles=None)
+
+    with pytest.raises(ValueError, match="cannot be bootstrapped"):
+        cls(bootstrap=boot)
+
+    # Also caught on assignment, which is how much of this suite builds them.
+    metric = cls()
+    with pytest.raises(ValueError, match="cannot be bootstrapped"):
+        metric.bootstrap = boot
+
+
+def test_value_time_metrics_still_work_without_bootstrap():
+    """The guard must not affect the un-bootstrapped use of these metrics."""
+    for cls in (
+        DeterministicMetrics.MaxValueTimeDelta,
+        Signatures.CenterOfTiming,
+    ):
+        metric = cls()
+        assert metric.bootstrap is None
+        assert metric.value_time_field_name == "value_time"
+
+    # And a bootstrap on a metric with no value_time dependence is unaffected.
+    boot = Bootstrappers.Stationary(seed=1, reps=10, quantiles=None)
+    kge = DeterministicMetrics.KlingGuptaEfficiency(bootstrap=boot)
+    assert kge.bootstrap is boot
+    fdc = Signatures.FlowDurationCurveSlope(bootstrap=boot)
+    assert fdc.bootstrap is boot
+
+
 def test_singleton_group_now_gets_quality_guards():
     """Groups of one are now subject to the sample-size/mean/variance guards.
 

--- a/tests/query/test_metrics_bootstrapping.py
+++ b/tests/query/test_metrics_bootstrapping.py
@@ -1083,6 +1083,64 @@ def test_value_time_metrics_still_work_without_bootstrap():
     assert fdc.bootstrap is boot
 
 
+@pytest.mark.session_scope_test_warehouse
+def test_sample_size_guard_nulls_small_groups_end_to_end(
+    session_scope_test_warehouse,
+):
+    """A group under minimum_sample_size returns null through the pipeline.
+
+    The warehouse has 72 rows per gage, above the default floor of 30, so no
+    guard fires on the full fixture. Filtering value_time brings every gage to
+    27 rows while leaving mean (0.49 / 10.49 / 145.6) and variance (0.081 /
+    0.081 / 913.6) well above their floors -- so this isolates the
+    sample-size guard specifically, rather than tripping several at once.
+
+    Worth having at the Spark level and not only as a unit test: this is the
+    behaviour change from routing singleton bootstrap groups through the
+    shared path, and it is what a user with fine-grained grouping will hit.
+    """
+    ev = session_scope_test_warehouse
+
+    small_group = [
+        TableFilter(
+            column="value_time",
+            operator=ops.lt,
+            value="2022-01-01 10:00:00",
+        )
+    ]
+
+    def run(**boot_kwargs):
+        kge = DeterministicMetrics.KlingGuptaEfficiency()
+        kge.bootstrap = Bootstrappers.CircularBlock(
+            seed=40, block_size=5, quantiles=[0.05, 0.95], reps=50,
+            **boot_kwargs,
+        )
+        kge.unpack_results = True
+        return (
+            ev.table("joined_timeseries")
+            .filter(filters=small_group)
+            .aggregate(metrics=[kge], group_by=["primary_location_id"])
+            .order_by("primary_location_id")
+            .to_pandas()
+        )
+
+    # Default floor of 30 against 27 rows -> null for every gage.
+    guarded = run()
+    assert guarded.index.size == 3
+    for col in ("kling_gupta_efficiency_0_05", "kling_gupta_efficiency_0_95"):
+        assert guarded[col].isna().all(), (
+            f"{col} should be null under the guard"
+        )
+
+    # Lowering the floor on the Bootstrapper is the escape hatch.
+    relaxed = run(minimum_sample_size=5)
+    assert relaxed.index.size == 3
+    for col in ("kling_gupta_efficiency_0_05", "kling_gupta_efficiency_0_95"):
+        assert relaxed[col].notna().all(), (
+            f"{col} should be populated at floor=5"
+        )
+
+
 def test_quality_guards_are_configurable_on_the_bootstrapper():
     """The guards are fields on the Bootstrappers model, so they can be tuned.
 

--- a/tests/query/test_metrics_bootstrapping.py
+++ b/tests/query/test_metrics_bootstrapping.py
@@ -1083,6 +1083,87 @@ def test_value_time_metrics_still_work_without_bootstrap():
     assert fdc.bootstrap is boot
 
 
+def test_quality_guards_are_configurable_on_the_bootstrapper():
+    """The guards are fields on the Bootstrappers model, so they can be tuned.
+
+    They belong there rather than on the aggregation call because they are
+    properties of a bootstrap configuration -- and because grouping already
+    works that way: bootstrap_group_key keys on the bootstrap config, so
+    metrics sharing a config necessarily share guards.
+    """
+    from teehr.metrics.bootstrap_funcs import create_shared_bootstrap_func
+
+    rng = np.random.default_rng(5)
+    n = 10                                   # below the default floor of 30
+    p = pd.Series(np.abs(rng.normal(10, 3, n)) + 0.1)
+    s = pd.Series(np.abs(rng.normal(9, 3, n)) + 0.1)
+
+    def kge_with(**kwargs):
+        return DeterministicMetrics.KlingGuptaEfficiency(
+            output_field_name="kge",
+            bootstrap=Bootstrappers.Stationary(
+                reps=20, seed=7, block_size=3, quantiles=[0.05, 0.95],
+                **kwargs,
+            ),
+        )
+
+    # Defaults unchanged from when they were hardcoded.
+    default = Bootstrappers.Stationary(reps=10)
+    assert default.minimum_sample_size == 30
+    assert default.minimum_mean == 0.01
+    assert default.minimum_variance == 0.000025
+
+    guarded = create_shared_bootstrap_func([kge_with()])(p, s)
+    assert guarded == {"kge": None}
+
+    relaxed = create_shared_bootstrap_func(
+        [kge_with(minimum_sample_size=5)]
+    )(p, s)
+    assert set(relaxed) == {"kge_0.05", "kge_0.95"}
+    assert all(np.isfinite(v) for v in relaxed.values())
+
+
+def test_differing_guards_do_not_share_a_bootstrap_group():
+    """Guards are part of bootstrap_group_key.
+
+    create_shared_bootstrap_func reads them from metrics[0].bootstrap, so if
+    two configs differing only in a guard shared a group, the first metric's
+    thresholds would silently apply to the others.
+    """
+    from teehr.metrics.bootstrap_funcs import bootstrap_group_key
+
+    strict = Bootstrappers.Stationary(reps=10, seed=1)
+    relaxed = Bootstrappers.Stationary(reps=10, seed=1, minimum_sample_size=5)
+
+    a = DeterministicMetrics.KlingGuptaEfficiency(
+        output_field_name="a", bootstrap=strict)
+    b = DeterministicMetrics.NashSutcliffeEfficiency(
+        output_field_name="b", bootstrap=relaxed)
+    c = DeterministicMetrics.RelativeMean(
+        output_field_name="c", bootstrap=Bootstrappers.Stationary(
+            reps=10, seed=1))
+
+    keys = {bootstrap_group_key(m) for m in (a, b, c)}
+    assert len(keys) == 2, "a differing guard must split the group"
+    assert bootstrap_group_key(a) == bootstrap_group_key(c)
+    assert bootstrap_group_key(a) != bootstrap_group_key(b)
+
+
+@pytest.mark.parametrize("boot_cls", [
+    Bootstrappers.Stationary,
+    Bootstrappers.CircularBlock,
+    Bootstrappers.Gumboot,
+])
+def test_guards_available_on_every_bootstrap_method(boot_cls):
+    """Declared on BootstrapBasemodel, so every method inherits them."""
+    boot = boot_cls(
+        reps=10, minimum_sample_size=5, minimum_mean=0.0, minimum_variance=0.0
+    )
+    assert boot.minimum_sample_size == 5
+    assert boot.minimum_mean == 0.0
+    assert boot.minimum_variance == 0.0
+
+
 def test_singleton_group_now_gets_quality_guards():
     """Groups of one are now subject to the sample-size/mean/variance guards.
 
@@ -1103,7 +1184,7 @@ def test_singleton_group_now_gets_quality_guards():
     )
 
     rng = np.random.default_rng(5)
-    n = 10                                   # below minimum_sample_size=30
+    n = 10                    # below the default minimum_sample_size of 30
     p = pd.Series(np.abs(rng.normal(10, 3, n)) + 0.1)
     s = pd.Series(np.abs(rng.normal(9, 3, n)) + 0.1)
 

--- a/tests/query/test_metrics_bootstrapping.py
+++ b/tests/query/test_metrics_bootstrapping.py
@@ -16,6 +16,38 @@ from teehr.metrics.bootstrap_funcs import _calculate_quantiles
 from teehr.querying.utils import derive_map_key_list, unpack_sdf_dict_columns
 
 
+def _assert_bootstrap_samples_match(teehr_results, manual_results):
+    """Compare teehr's bootstrap samples against a hand-rolled arch run.
+
+    Both sides compute in float64 (callers cast the manual inputs; teehr's
+    vectorized engine casts via np.asarray(args[0], dtype=float)), so this is
+    a like-for-like comparison and the tolerance only has to absorb the final
+    float32 cast of the output column -- a couple of ULPs.
+
+    This used to assert exact float32 equality, which held only because
+    teehr's legacy path ran the identical code on the identical dtype. The
+    warehouse stores primary_value/secondary_value as float32, and the legacy
+    path passes those Series to the closures unchanged, so np.nansum/np.std
+    accumulated in float32. Measured on gage-A, KGE, 500 reps:
+
+        vectorized vs legacy (float32 in)   max rel 2.59e-06
+        vectorized vs legacy (float64 in)   max rel 7.48e-15   <- algorithmic
+        legacy float64 vs legacy float32    max rel 2.59e-06
+
+    The engines agree to ~1e-15; the whole gap was input dtype. Rather than
+    widen the tolerance until that gap fits -- which would have meant a
+    tolerance of 1e-4 to accommodate degenerate log-transform replicates where
+    KGE reaches -123 -- the callers now feed the manual run float64 so the
+    confound is gone.
+
+    Manual runs stay float32 and exact where the engine cannot apply (Gumboot).
+    """
+    assert teehr_results.shape == manual_results.shape
+    np.testing.assert_allclose(
+        teehr_results, manual_results, rtol=1e-6, atol=1e-7, equal_nan=True
+    )
+
+
 BOOT_YEAR_FILE = Path(
     "tests",
     "data",
@@ -120,8 +152,14 @@ def test_circularblock_bootstrapping(session_scope_test_warehouse):
     df = ev.table("joined_timeseries").to_pandas()
     df_gageA = df.groupby("primary_location_id").get_group("gage-A")
 
-    p = df_gageA.primary_value
-    s = df_gageA.secondary_value
+    # float64, to match what teehr computes in. The warehouse stores these
+    # as float32; the vectorized engine casts once via
+    # np.asarray(args[0], dtype=float) and accumulates in float64, so a
+    # float32 manual run would be comparing two different precisions and
+    # the residual would be input dtype, not arithmetic. Casting here keeps
+    # the comparison like-for-like and the tolerance meaningful.
+    p = df_gageA.primary_value.astype("float64")
+    s = df_gageA.secondary_value.astype("float64")
 
     bs = CircularBlockBootstrap(
         kge.bootstrap.block_size,
@@ -158,7 +196,7 @@ def test_circularblock_bootstrapping(session_scope_test_warehouse):
     )
     manual_results = np.sort(results.ravel()).astype(np.float32)
 
-    assert (teehr_results == manual_results).all()
+    _assert_bootstrap_samples_match(teehr_results, manual_results)
 
     assert isinstance(metrics_df, pd.DataFrame)
     assert metrics_df.index.size == 1
@@ -185,8 +223,14 @@ def test_stationary_bootstrapping(session_scope_test_warehouse):
     df = ev.table("joined_timeseries").to_pandas()
     df_gageA = df.groupby("primary_location_id").get_group("gage-A")
 
-    p = df_gageA.primary_value
-    s = df_gageA.secondary_value
+    # float64, to match what teehr computes in. The warehouse stores these
+    # as float32; the vectorized engine casts once via
+    # np.asarray(args[0], dtype=float) and accumulates in float64, so a
+    # float32 manual run would be comparing two different precisions and
+    # the residual would be input dtype, not arithmetic. Casting here keeps
+    # the comparison like-for-like and the tolerance meaningful.
+    p = df_gageA.primary_value.astype("float64")
+    s = df_gageA.secondary_value.astype("float64")
 
     bs = StationaryBootstrap(
         kge.bootstrap.block_size,
@@ -223,7 +267,7 @@ def test_stationary_bootstrapping(session_scope_test_warehouse):
     )
     manual_results = np.sort(results.ravel()).astype(np.float32)
 
-    assert (teehr_results == manual_results).all()
+    _assert_bootstrap_samples_match(teehr_results, manual_results)
     assert isinstance(metrics_df, pd.DataFrame)
     assert metrics_df.index.size == 1
     assert metrics_df.columns.size == 2
@@ -467,8 +511,14 @@ def test_bootstrapping_transforms(session_scope_test_warehouse):
     df = ev.table("joined_timeseries").to_pandas()
     df_gageA = df.groupby("primary_location_id").get_group("gage-A")
 
-    p = df_gageA.primary_value
-    s = df_gageA.secondary_value
+    # float64, to match what teehr computes in. The warehouse stores these
+    # as float32; the vectorized engine casts once via
+    # np.asarray(args[0], dtype=float) and accumulates in float64, so a
+    # float32 manual run would be comparing two different precisions and
+    # the residual would be input dtype, not arithmetic. Casting here keeps
+    # the comparison like-for-like and the tolerance meaningful.
+    p = df_gageA.primary_value.astype("float64")
+    s = df_gageA.secondary_value.astype("float64")
 
     bs = CircularBlockBootstrap(
         kge.bootstrap.block_size,
@@ -505,7 +555,7 @@ def test_bootstrapping_transforms(session_scope_test_warehouse):
     )
     manual_results = np.sort(results.ravel()).astype(np.float32)
 
-    assert (teehr_results == manual_results).all()
+    _assert_bootstrap_samples_match(teehr_results, manual_results)
     assert isinstance(metrics_df, pd.DataFrame)
     assert metrics_df.index.size == 1
     assert metrics_df.columns.size == 2

--- a/tests/query/test_metrics_bootstrapping.py
+++ b/tests/query/test_metrics_bootstrapping.py
@@ -876,11 +876,15 @@ def test_shared_bootstrap_quantile_columns_correct(
 
 
 @pytest.mark.session_scope_test_warehouse
-def test_shared_bootstrap_singleton_group_unchanged(
+def test_shared_bootstrap_singleton_takes_shared_path(
     session_scope_test_warehouse,
 ):
-    """A single metric with quantile bootstrap should produce correct columns
-    through the shared path (singleton group, no actual sharing).
+    """A single quantile-bootstrap metric produces correct columns.
+
+    Groups of one used to be special-cased through ``boot.func(ref)`` -- the
+    legacy per-replicate loop, which never consulted the vectorized engine.
+    They now take the same shared path as every other group, so this asserts
+    the output columns survive the temp-column + expansion round trip.
     """
     ev = session_scope_test_warehouse
 
@@ -906,6 +910,118 @@ def test_shared_bootstrap_singleton_group_unchanged(
     }
     assert expected_cols.issubset(set(result_df.columns))
     assert result_df.index.size == 3
+
+
+@pytest.mark.session_scope_test_warehouse
+def test_duplicate_quantiles_expand_to_one_column(
+    session_scope_test_warehouse,
+):
+    """A repeated quantile must not crash the map reconstruction.
+
+    ``quantiles=[0.5, 0.50]`` is a supported config (see
+    test_derive_map_key_list), and the dict the UDF returns collapses the
+    repeat to one entry. ``F.create_map`` in
+    ``_materialize_shared_bootstrap_columns`` did not, so Spark's default
+    ``mapKeyDedupPolicy=EXCEPTION`` raised DUPLICATED_MAP_KEY at collect time.
+    Routing singletons through the shared path widened that from multi-metric
+    groups to every bootstrap group, so the dedupe is what makes Stage 3 safe.
+    """
+    ev = session_scope_test_warehouse
+
+    boot = Bootstrappers.CircularBlock(
+        seed=40, block_size=100, quantiles=[0.5, 0.50], reps=50
+    )
+    kge = DeterministicMetrics.KlingGuptaEfficiency()
+    kge.bootstrap = boot
+
+    result_df = (
+        ev.table("joined_timeseries")
+        .aggregate(metrics=[kge], group_by=["primary_location_id"])
+        .to_pandas()
+    )
+
+    assert result_df.index.size == 3
+    # One key, not two -- matching what derive_map_key_list predicts.
+    assert derive_map_key_list(kge) == ["kling_gupta_efficiency_0.5"]
+    for value in result_df.kling_gupta_efficiency:
+        assert list(value.keys()) == ["kling_gupta_efficiency_0.5"]
+
+
+@pytest.mark.session_scope_test_warehouse
+def test_singleton_group_is_routed_through_the_shared_path(
+    session_scope_test_warehouse,
+):
+    """format.py must build a shared-path expansion for a group of one.
+
+    This is the Stage 3 change itself: the singleton branch produced a
+    directly-aliased column and NO expansion entry, so a lone bootstrapped
+    metric bypassed create_shared_bootstrap_func (and therefore the vectorized
+    engine) entirely. Asserting on `expansions` tests the routing rather than
+    the UDF, which the other singleton tests exercise directly.
+    """
+    from teehr.metrics.bootstrap_funcs import partition_metrics_by_bootstrap
+    from teehr.metrics.format import _build_shared_bootstrap_udfs
+
+    ev = session_scope_test_warehouse
+
+    boot = Bootstrappers.CircularBlock(
+        seed=40, block_size=100, quantiles=[0.05, 0.95], reps=20
+    )
+    kge = DeterministicMetrics.KlingGuptaEfficiency()
+    kge.bootstrap = boot
+
+    gp = ev.table("joined_timeseries").to_sdf().groupBy("primary_location_id")
+    _, boot_groups = partition_metrics_by_bootstrap([kge])
+    assert [len(g) for g in boot_groups.values()] == [1]
+
+    func_list, expansions = _build_shared_bootstrap_udfs(boot_groups, gp)
+
+    assert len(func_list) == 1
+    assert len(expansions) == 1, "singleton group produced no expansion entry"
+    temp_col, group_metrics = expansions[0]
+    assert temp_col.startswith("_bsgrp_")
+    assert [m.output_field_name for m in group_metrics] == [
+        "kling_gupta_efficiency"
+    ]
+
+
+def test_singleton_group_now_gets_quality_guards():
+    """Groups of one are now subject to the sample-size/mean/variance guards.
+
+    Deliberate behavior change. The guards live in
+    ``create_shared_bootstrap_func``, which singleton groups previously did not
+    reach -- so one bootstrapped metric would compute on a 5-sample group while
+    the same metric plus a second one returned nulls for both. The retained
+    ``create_stationary_func`` still has no guards, which is what makes the
+    difference visible here.
+
+    Pure-python rather than Spark: the checked-in warehouse has 72 rows per
+    gage with variance well above the floor, so no guard fires anywhere in the
+    suite and a Spark-level test could not detect this.
+    """
+    from teehr.metrics.bootstrap_funcs import (
+        create_shared_bootstrap_func,
+        create_stationary_func,
+    )
+
+    rng = np.random.default_rng(5)
+    n = 10                                   # below minimum_sample_size=30
+    p = pd.Series(np.abs(rng.normal(10, 3, n)) + 0.1)
+    s = pd.Series(np.abs(rng.normal(9, 3, n)) + 0.1)
+
+    boot = Bootstrappers.Stationary(
+        seed=7, reps=20, block_size=3, quantiles=[0.05, 0.95]
+    )
+    kge = DeterministicMetrics.KlingGuptaEfficiency()
+    kge.bootstrap = boot
+
+    guarded = create_shared_bootstrap_func([kge])(p, s)
+    assert guarded == {"kling_gupta_efficiency": None}
+
+    # The old singleton path computed a value for the same input.
+    unguarded = create_stationary_func(kge)(p, s)
+    assert unguarded  # non-empty: a real quantile map, not a null
+    assert all(np.isfinite(v) for v in unguarded.values())
 
 
 @pytest.mark.session_scope_test_warehouse

--- a/tests/query/test_vectorized_bootstrap_funcs.py
+++ b/tests/query/test_vectorized_bootstrap_funcs.py
@@ -345,6 +345,41 @@ def test_mixed_group_enters_vectorized_engine(monkeypatch):
     assert _can_use_vectorized_engine(boot, metrics) is True
 
 
+def test_singleton_group_uses_vectorized_engine(monkeypatch):
+    """A lone bootstrapped metric must reach the engine, and match legacy.
+
+    format.py used to route groups of one through ``boot.func(ref)``, which
+    never consults the gate -- so the flag bought a single-metric request
+    nothing at all. Groups of one now take the shared path like any other.
+    """
+    from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine
+
+    n, reps = 55, 120
+    p = _random_series(n, seed=610)
+    s = _random_series(n, seed=611, loc=9, scale=3)
+
+    boot = Bootstrappers.Stationary(
+        seed=808, reps=reps, block_size=5, quantiles=[0.05, 0.95]
+    )
+
+    def build():
+        return [DeterministicMetrics.KlingGuptaEfficiency(
+            output_field_name="kge", bootstrap=boot)]
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
+    assert _can_use_vectorized_engine(boot, build()) is True
+    vectorized_result = create_shared_bootstrap_func(build())(p, s)
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
+    legacy_result = create_shared_bootstrap_func(build())(p, s)
+
+    assert set(legacy_result.keys()) == set(vectorized_result.keys())
+    for key in legacy_result:
+        assert vectorized_result[key] == pytest.approx(
+            legacy_result[key], rel=1e-9, abs=1e-12
+        )
+
+
 def test_engine_flag_falls_back_when_no_metric_is_covered(monkeypatch):
     """With nothing covered there is no work for the engine; use bs.apply."""
     from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine

--- a/tests/query/test_vectorized_bootstrap_funcs.py
+++ b/tests/query/test_vectorized_bootstrap_funcs.py
@@ -3,11 +3,19 @@
 These tests validate that vectorized_bootstrap_funcs.py produces the same
 results as the existing per-replicate loop in bootstrap_funcs.py, at three
 levels: (1) resample index construction, (2) individual metric kernels, and
-(3) the full shared-bootstrap UDF body end-to-end. The vectorized engine is
-gated behind the TEEHR_BOOTSTRAP_ENGINE=vectorized env var (see
-bootstrap_funcs._can_use_vectorized_engine) and is off by default, so these
-tests explicitly enable it via monkeypatch where needed.
+(3) the full shared-bootstrap UDF body end-to-end.
+
+The vectorized engine is the default; TEEHR_BOOTSTRAP_ENGINE=legacy selects
+the per-rep loop (see bootstrap_funcs._vectorized_engine_enabled). Every test
+here that compares the two engines names BOTH explicitly via monkeypatch,
+rather than deleting the env var to get one of them. That matters: relying on
+the default would mean a future flip silently turns a legacy-vs-vectorized
+comparison into vectorized-vs-vectorized, which passes while testing nothing.
+The single exception is test_engine_flag_defaults_to_vectorized, whose whole
+purpose is to assert the default.
 """
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -387,7 +395,7 @@ def test_shared_bootstrap_vectorized_matches_legacy_end_to_end(monkeypatch):
         DeterministicMetrics.PearsonCorrelation(output_field_name="pearson", bootstrap=boot),
     ]
 
-    monkeypatch.delenv("TEEHR_BOOTSTRAP_ENGINE", raising=False)
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
     legacy_func = create_shared_bootstrap_func(metrics)
     legacy_result = legacy_func(p, s)
 
@@ -415,7 +423,7 @@ def test_shared_bootstrap_vectorized_matches_legacy_circularblock(monkeypatch):
         DeterministicMetrics.PearsonCorrelation(output_field_name="pearson", bootstrap=boot),
     ]
 
-    monkeypatch.delenv("TEEHR_BOOTSTRAP_ENGINE", raising=False)
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
     legacy_result = create_shared_bootstrap_func(metrics)(p, s)
 
     monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
@@ -426,14 +434,51 @@ def test_shared_bootstrap_vectorized_matches_legacy_circularblock(monkeypatch):
         assert vectorized_result[key] == pytest.approx(legacy_result[key], rel=1e-9, abs=1e-12)
 
 
-def test_engine_flag_defaults_to_legacy(monkeypatch):
-    """Without the env var set, the vectorized path must not be used."""
+def test_engine_flag_defaults_to_vectorized(monkeypatch):
+    """With no env var set, the vectorized path is used.
+
+    Inverted when the default flipped. This is the ONE test that is meant to
+    depend on the default -- every other test in this module names its engine
+    explicitly, so that flipping the default cannot turn a legacy-vs-vectorized
+    comparison into a vectorized-vs-vectorized one that passes while testing
+    nothing.
+    """
     from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine
 
     monkeypatch.delenv("TEEHR_BOOTSTRAP_ENGINE", raising=False)
     boot = Bootstrappers.Stationary(seed=1, reps=10, quantiles=None)
     metrics = [DeterministicMetrics.RelativeMean(bootstrap=boot)]
+    assert _can_use_vectorized_engine(boot, metrics) is True
+
+
+@pytest.mark.parametrize("value", ["legacy", "LEGACY", " legacy "])
+def test_legacy_remains_available_as_an_escape_hatch(monkeypatch, value):
+    """TEEHR_BOOTSTRAP_ENGINE=legacy must still select the per-rep loop.
+
+    The two engines are meant to be numerically identical, so if they ever are
+    not, falling back should be one env var rather than a release.
+    """
+    from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", value)
+    boot = Bootstrappers.Stationary(seed=1, reps=10, quantiles=None)
+    metrics = [DeterministicMetrics.RelativeMean(bootstrap=boot)]
     assert _can_use_vectorized_engine(boot, metrics) is False
+
+
+def test_unrecognized_engine_value_warns_and_uses_default(monkeypatch, caplog):
+    """A typo must not silently pick an engine.
+
+    Which way a misspelling falls is invisible in the results -- the engines
+    agree numerically -- so without the warning the only symptom would be an
+    unexplained slowdown, or nothing at all.
+    """
+    from teehr.metrics.bootstrap_funcs import _vectorized_engine_enabled
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacyy")
+    with caplog.at_level(logging.WARNING):
+        assert _vectorized_engine_enabled() is True
+    assert "Unrecognized TEEHR_BOOTSTRAP_ENGINE" in caplog.text
 
 
 def test_engine_flag_falls_back_for_gumboot(monkeypatch):
@@ -687,7 +732,7 @@ def test_end_to_end_reps_1000_scale(monkeypatch):
         DeterministicMetrics.PearsonCorrelation(output_field_name="pearson", bootstrap=boot),
     ]
 
-    monkeypatch.delenv("TEEHR_BOOTSTRAP_ENGINE", raising=False)
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
     legacy_result = create_shared_bootstrap_func(metrics)(p, s)
 
     monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
@@ -720,7 +765,7 @@ def test_shared_bootstrap_keys_match_static_derivation(monkeypatch):
     for metric in metrics:
         expected.update(derive_map_key_list(metric))
 
-    monkeypatch.delenv("TEEHR_BOOTSTRAP_ENGINE", raising=False)
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
     assert set(create_shared_bootstrap_func(metrics)(p, s).keys()) == expected
 
     monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")

--- a/tests/query/test_vectorized_bootstrap_funcs.py
+++ b/tests/query/test_vectorized_bootstrap_funcs.py
@@ -250,6 +250,7 @@ def test_registry_contents_are_deliberate():
         "RelativeBias", "RelativeMaximum", "RelativeMean", "RelativeMedian",
         "RelativeMinimum", "RelativeStandardDeviation",
         "RootMeanSquareError", "RootMeanStandardDeviationRatio", "Rsquared",
+        "VariabilityRatio",
         # Signature (single-field)
         "Average", "Count", "Maximum", "Minimum", "Sum", "Variance",
     }

--- a/tests/query/test_vectorized_bootstrap_funcs.py
+++ b/tests/query/test_vectorized_bootstrap_funcs.py
@@ -322,8 +322,18 @@ def test_engine_flag_falls_back_for_gumboot(monkeypatch):
     assert _can_use_vectorized_engine(boot, metrics) is False
 
 
-def test_engine_flag_falls_back_for_unvectorized_metric(monkeypatch):
-    """A metric without a vectorized kernel must force the legacy fallback."""
+def test_mixed_group_enters_vectorized_engine(monkeypatch):
+    """A group with SOME covered metrics must still use the vectorized engine.
+
+    This assertion is inverted from the version that shipped, which required
+    every metric in the group to have a kernel. That was a coarse proxy for
+    "an uncovered metric is never computed by a kernel" -- and it cost a mixed
+    group ~8x, since bootstrap_group_key excludes metric class and so groups
+    are heterogeneous by design. The property is now enforced structurally
+    (a class absent from the registry can only reach the scalar-closure branch
+    of the dispatch), and asserted directly by the equivalence tests below,
+    which are strictly stronger than the proxy was.
+    """
     from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine
 
     monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
@@ -332,7 +342,172 @@ def test_engine_flag_falls_back_for_unvectorized_metric(monkeypatch):
         DeterministicMetrics.RelativeMean(bootstrap=boot),
         DeterministicMetrics.SpearmanCorrelation(bootstrap=boot),  # not in registry
     ]
+    assert _can_use_vectorized_engine(boot, metrics) is True
+
+
+def test_engine_flag_falls_back_when_no_metric_is_covered(monkeypatch):
+    """With nothing covered there is no work for the engine; use bs.apply."""
+    from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
+    boot = Bootstrappers.Stationary(seed=1, reps=10, quantiles=None)
+    metrics = [DeterministicMetrics.SpearmanCorrelation(bootstrap=boot)]
     assert _can_use_vectorized_engine(boot, metrics) is False
+
+
+@pytest.mark.parametrize("transform", [None, "log"])
+@pytest.mark.parametrize("quantiles", [[0.05, 0.95], None])
+def test_mixed_group_matches_legacy_end_to_end(
+    monkeypatch, transform, quantiles
+):
+    """A group mixing covered and uncovered metrics must match legacy exactly.
+
+    This is the test the per-metric fallback exists to make pass: the kernels
+    handle what they can on the batched matrices while SpearmanCorrelation and
+    MeanError go through their own scalar closures, all on one index matrix.
+    """
+    n, reps = 60, 200
+    p = _random_series(n, seed=210)
+    s = _random_series(n, seed=211, loc=9.5, scale=4)
+
+    boot = Bootstrappers.Stationary(
+        seed=4242, reps=reps, block_size=6, quantiles=quantiles
+    )
+
+    def build():
+        return [
+            DeterministicMetrics.RelativeMean(
+                output_field_name="rm", bootstrap=boot, transform=transform),
+            DeterministicMetrics.NashSutcliffeEfficiency(
+                output_field_name="nse", bootstrap=boot, transform=transform),
+            DeterministicMetrics.SpearmanCorrelation(      # no kernel
+                output_field_name="spearman", bootstrap=boot,
+                transform=transform),
+            DeterministicMetrics.KlingGuptaEfficiency(
+                output_field_name="kge", bootstrap=boot, transform=transform),
+            DeterministicMetrics.MeanError(               # no kernel
+                output_field_name="me", bootstrap=boot, transform=transform),
+        ]
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
+    legacy_result = create_shared_bootstrap_func(build())(p, s)
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
+    vectorized_result = create_shared_bootstrap_func(build())(p, s)
+
+    assert set(legacy_result.keys()) == set(vectorized_result.keys())
+    for key in legacy_result:
+        expected, actual = legacy_result[key], vectorized_result[key]
+        if quantiles is None:
+            np.testing.assert_allclose(
+                actual, expected, rtol=1e-9, atol=1e-12, equal_nan=True
+            )
+        else:
+            assert actual == pytest.approx(expected, rel=1e-9, abs=1e-12)
+
+
+def test_fallback_metric_sees_same_draws_as_kernel(monkeypatch):
+    """A covered metric and an uncovered clone of it must agree exactly.
+
+    Direct assertion that the shared bootstrap is still shared. Rather than
+    lean on a formula identity between two different metrics, this subclasses
+    RelativeBias so the formula is identical by construction, and leaves the
+    subclass out of the registry. One copy is then routed through the kernel
+    and the other through the per-rep fallback loop. If the two subsets saw
+    different draws, the columns would diverge.
+    """
+    n, reps = 50, 150
+    p = _random_series(n, seed=310)
+    s = _random_series(n, seed=311, loc=9, scale=3)
+
+    class RelativeBiasClone(DeterministicMetrics.RelativeBias):
+        """Same formula, deliberately absent from VECTORIZED_METRIC_FUNCS."""
+
+    assert "RelativeBiasClone" not in VECTORIZED_METRIC_FUNCS
+
+    boot = Bootstrappers.Stationary(
+        seed=515, reps=reps, block_size=5, quantiles=None
+    )
+    metrics = [
+        DeterministicMetrics.RelativeBias(
+            output_field_name="via_kernel", bootstrap=boot),
+        RelativeBiasClone(
+            output_field_name="via_fallback", bootstrap=boot),
+    ]
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
+    from teehr.metrics.bootstrap_funcs import _can_use_vectorized_engine
+    assert _can_use_vectorized_engine(boot, metrics) is True
+
+    result = create_shared_bootstrap_func(metrics)(p, s)
+    np.testing.assert_allclose(
+        result["via_fallback"], result["via_kernel"],
+        rtol=1e-9, atol=1e-12, equal_nan=True,
+    )
+
+
+@pytest.mark.parametrize("max_cells", [1, 7, 10**9])
+def test_rep_chunking_is_bit_identical(max_cells):
+    """Chunking the index matrix must not perturb the RNG stream."""
+    from teehr.metrics.bootstrap_funcs import _make_bs_object
+
+    n, reps = 40, 60
+    p = _random_series(n, seed=410)
+    s = _random_series(n, seed=411, loc=8, scale=2)
+
+    boot = Bootstrappers.Stationary(
+        seed=717, reps=reps, block_size=4, quantiles=[0.1, 0.9]
+    )
+    metrics = [
+        DeterministicMetrics.RelativeMean(
+            output_field_name="rm", bootstrap=boot),
+        DeterministicMetrics.MeanError(
+            output_field_name="me", bootstrap=boot),
+    ]
+    funcs = [m.func(m) for m in metrics]
+
+    def run(cells):
+        bs = _make_bs_object(boot, (p, s))
+        return compute_vectorized_shared_bootstrap(
+            metrics, funcs, (p, s), bs, reps, boot.quantiles,
+            max_matrix_cells=cells,
+        )
+
+    reference = run(10**9)
+    actual = run(max_cells)
+    assert set(actual) == set(reference)
+    for key in reference:
+        assert actual[key] == pytest.approx(reference[key], rel=0, abs=0)
+
+
+def test_resample_args_matches_arch_resample():
+    """resample_args must reproduce arch's _resample: values, index, type."""
+    from arch.bootstrap import StationaryBootstrap
+    from teehr.metrics.vectorized_bootstrap_funcs import resample_args
+
+    n, reps = 12, 4
+    p = pd.Series(np.arange(n, dtype=float) + 1.0)
+    s = pd.Series((np.arange(n, dtype=float) + 1.0) * 10)
+
+    seen = []
+
+    def probe(*args):
+        seen.append(tuple(args))
+        return np.asarray([0.0])
+
+    StationaryBootstrap(3, p, s, seed=42).apply(probe, reps)
+    # apply() evaluates the func once on the un-resampled data to infer shape
+    # and discards it, consuming no RNG; the draws start at index 1.
+    drawn = seen[1:]
+
+    bs = StationaryBootstrap(3, p, s, seed=42)
+    for rep in range(reps):
+        indices = np.asarray(bs.update_indices())
+        mine = resample_args((p, s), indices)
+        for got, expected in zip(mine, drawn[rep]):
+            assert type(got) is type(expected)
+            np.testing.assert_array_equal(got.values, expected.values)
+            assert list(got.index) == list(expected.index)
 
 
 def test_end_to_end_reps_1000_scale(monkeypatch):

--- a/tests/query/test_vectorized_bootstrap_funcs.py
+++ b/tests/query/test_vectorized_bootstrap_funcs.py
@@ -18,7 +18,7 @@ from teehr.metrics.bootstrap_funcs import (
     create_shared_bootstrap_func,
 )
 from teehr.metrics.models.bootstrap import Bootstrappers
-from teehr.querying.utils import derive_map_key_list
+from teehr.querying.utils import derive_map_key_list, parse_fields_to_list
 from teehr.metrics.vectorized_bootstrap_funcs import (
     VECTORIZED_METRIC_FUNCS,
     build_index_matrix,
@@ -108,6 +108,15 @@ def _metric_class(name):
     return cls
 
 
+def _is_single_field(metric):
+    """Whether the metric's closure takes only the primary series."""
+    if hasattr(metric, "get_input_field_names"):
+        fields = metric.get_input_field_names()
+    else:
+        fields = metric.input_field_names
+    return len(parse_fields_to_list(fields)) == 1
+
+
 def _gappy_matrices(reps, n, seed=17):
     """Matrices with non-finite values in p and s at DIFFERENT indices.
 
@@ -155,15 +164,130 @@ def test_kernel_matches_scalar_closure_on_gappy_data(metric_name, transform):
 
     p_mat, s_mat = _gappy_matrices(reps, n)
 
-    expected = np.array([
-        scalar_func(pd.Series(p_mat[r]), pd.Series(s_mat[r]))
-        for r in range(reps)
-    ])
-    actual = kernel(p_mat.copy(), s_mat.copy(), metric)
+    # Signature metrics are single-field: the closure takes p alone and the
+    # kernel receives s_mat=None, exactly as
+    # compute_vectorized_shared_bootstrap passes it.
+    if _is_single_field(metric):
+        expected = np.array([
+            scalar_func(pd.Series(p_mat[r])) for r in range(reps)
+        ])
+        actual = kernel(p_mat.copy(), None, metric)
+    else:
+        expected = np.array([
+            scalar_func(pd.Series(p_mat[r]), pd.Series(s_mat[r]))
+            for r in range(reps)
+        ])
+        actual = kernel(p_mat.copy(), s_mat.copy(), metric)
 
     np.testing.assert_allclose(
         actual, expected, rtol=1e-9, atol=1e-12, equal_nan=True
     )
+
+
+@pytest.mark.parametrize("metric_name", sorted(VECTORIZED_METRIC_FUNCS))
+def test_kernels_do_not_mutate_their_inputs(metric_name):
+    """Kernels must treat p_mat/s_mat as read-only.
+
+    compute_vectorized_shared_bootstrap hands the SAME two matrices to every
+    kernel in the group, so one in-place write would silently corrupt every
+    metric evaluated after it. Note the inputs are passed directly here, not
+    copied -- the older kernel tests defensively pass .copy(), which would
+    mask exactly this bug.
+    """
+    metric = _metric_class(metric_name)()
+    kernel = VECTORIZED_METRIC_FUNCS[metric_name]
+    p_mat, s_mat = _gappy_matrices(6, 20)
+    p_ref, s_ref = p_mat.copy(), s_mat.copy()
+
+    if _is_single_field(metric):
+        kernel(p_mat, None, metric)
+    else:
+        kernel(p_mat, s_mat, metric)
+        np.testing.assert_array_equal(s_mat, s_ref)
+    np.testing.assert_array_equal(p_mat, p_ref)
+
+
+def test_registry_entries_are_bootstrap_vectorizable():
+    """Every registry key must name a real metric the kernel contract fits."""
+    for name in sorted(VECTORIZED_METRIC_FUNCS):
+        metric = _metric_class(name)()
+        fields = parse_fields_to_list(
+            metric.get_input_field_names()
+            if hasattr(metric, "get_input_field_names")
+            else metric.input_field_names
+        )
+        assert len(fields) <= 2, f"{name} takes {len(fields)} input fields"
+        assert not metric.attrs.get("requires_threshold_field", False), (
+            f"{name} needs a threshold column the kernels have no slot for"
+        )
+        assert getattr(metric, "value_time_field_name", None) is None, (
+            f"{name} depends on value_time, which the gate refuses"
+        )
+
+
+def test_registry_contents_are_deliberate():
+    """Change-detection tripwire: renaming or dropping a kernel must fail here.
+
+    Parity coverage comes from the registry-driven tests; this list exists so
+    that a metric class rename, or an accidental removal, is caught rather
+    than silently shrinking the covered set.
+    """
+    assert set(VECTORIZED_METRIC_FUNCS) == {
+        # Deterministic
+        "KlingGuptaEfficiency", "KlingGuptaEfficiencyMod1",
+        "KlingGuptaEfficiencyMod2", "MaxValueDelta", "MeanAbsoluteError",
+        "MeanAbsoluteRelativeError", "MeanError", "MeanSquareError",
+        "MultiplicativeBias", "NashSutcliffeEfficiency",
+        "NormalizedNashSutcliffeEfficiency", "PearsonCorrelation",
+        "RelativeBias", "RelativeMaximum", "RelativeMean", "RelativeMedian",
+        "RelativeMinimum", "RelativeStandardDeviation",
+        "RootMeanSquareError", "RootMeanStandardDeviationRatio", "Rsquared",
+        # Signature (single-field)
+        "Average", "Count", "Maximum", "Minimum", "Sum", "Variance",
+    }
+
+
+def test_single_field_group_matches_legacy_end_to_end(monkeypatch):
+    """Signature metrics run through the engine with args=(p,) only.
+
+    compute_vectorized_shared_bootstrap takes its arity from len(args), so
+    s_mat is None here. bootstrap_group_key includes the input-field tuple,
+    so these form their own group and can never mix with two-field metrics --
+    asserted below, since the s_mat=None contract depends on it.
+    """
+    from teehr.metrics.bootstrap_funcs import bootstrap_group_key
+
+    n, reps = 50, 150
+    p = _random_series(n, seed=710)
+
+    boot = Bootstrappers.Stationary(
+        seed=909, reps=reps, block_size=5, quantiles=[0.05, 0.95]
+    )
+
+    def build():
+        return [
+            Signatures.Average(output_field_name="avg", bootstrap=boot),
+            Signatures.Maximum(output_field_name="mx", bootstrap=boot),
+            Signatures.Variance(output_field_name="var", bootstrap=boot),
+            Signatures.Count(output_field_name="cnt", bootstrap=boot),
+        ]
+
+    keys = {bootstrap_group_key(m) for m in build()}
+    assert len(keys) == 1, "signature metrics should share one group"
+    two_field = DeterministicMetrics.KlingGuptaEfficiency(bootstrap=boot)
+    assert bootstrap_group_key(two_field) not in keys
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "legacy")
+    legacy_result = create_shared_bootstrap_func(build())(p)
+
+    monkeypatch.setenv("TEEHR_BOOTSTRAP_ENGINE", "vectorized")
+    vectorized_result = create_shared_bootstrap_func(build())(p)
+
+    assert set(legacy_result.keys()) == set(vectorized_result.keys())
+    for key in legacy_result:
+        assert vectorized_result[key] == pytest.approx(
+            legacy_result[key], rel=1e-9, abs=1e-12
+        )
 
 
 def test_pairwise_mask_applied_without_transform():

--- a/tests/query/test_vectorized_bootstrap_funcs.py
+++ b/tests/query/test_vectorized_bootstrap_funcs.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from teehr import DeterministicMetrics
+from teehr import DeterministicMetrics, Signatures
 from teehr.metrics.bootstrap_funcs import (
     _make_bs_object,
     create_shared_bootstrap_func,
@@ -97,6 +97,126 @@ def test_vectorized_kernel_matches_scalar_closure(metric_cls, extra_kwargs, add_
     actual = kernel(p_mat.copy(), s_mat.copy(), metric)
 
     np.testing.assert_allclose(actual, expected, rtol=1e-9, atol=1e-12)
+
+
+def _metric_class(name):
+    """Resolve a VECTORIZED_METRIC_FUNCS key to its metric class."""
+    cls = getattr(DeterministicMetrics, name, None)
+    if cls is None:
+        cls = getattr(Signatures, name, None)
+    assert cls is not None, f"{name!r} in the registry is not a metric class"
+    return cls
+
+
+def _gappy_matrices(reps, n, seed=17):
+    """Matrices with non-finite values in p and s at DIFFERENT indices.
+
+    The offset placement is the point: it makes the p-only valid count, the
+    s-only valid count, and the pairwise valid count all differ, so a kernel
+    that masks per-series instead of pairwise gives a different answer.
+    """
+    rng = np.random.default_rng(seed)
+    p = np.abs(rng.normal(10, 3, size=(reps, n))) + 0.1
+    s = np.abs(rng.normal(9, 4, size=(reps, n))) + 0.1
+    p[:, 2] = np.nan
+    s[:, 5] = np.nan
+    p[0, :] = np.nan          # all-NaN row -> empty after the drop
+    p[1, 7] = np.inf          # inf is dropped by the scalar path, not skipped
+    s[2, 4] = -np.inf
+    return p, s
+
+
+@pytest.mark.parametrize("metric_name", sorted(VECTORIZED_METRIC_FUNCS))
+@pytest.mark.parametrize("transform", [None, "sqrt", "log"])
+def test_kernel_matches_scalar_closure_on_gappy_data(metric_name, transform):
+    """Kernels must match the scalar closures when the data has gaps.
+
+    Regression test for two bugs that shipped together and were invisible to
+    the clean-data tests above:
+
+    1. ``deterministic_funcs._transform`` gated its non-finite drop on a
+       transform being set, so with ``transform=None`` NaNs reached the
+       reduction -- where ``np.sum``/``np.mean``/etc. on a pd.Series skip them
+       (pandas dispatch) but ``np.median``/``np.cov``/``np.corrcoef`` propagate
+       them (numpy dispatch). RelativeMedian, PearsonCorrelation and
+       KlingGuptaEfficiency returned NaN where their kernels returned a number.
+    2. ``_vectorized_transform`` returned early when no transform was set,
+       skipping the pairwise mask, so kernels reduced p and s over different
+       valid subsets.
+
+    The scalar closure is called with **pd.Series**, not numpy rows: numpy rows
+    would propagate NaN through every reduction and so validate a code path
+    that arch never exercises (it passes Series).
+    """
+    reps, n = 6, 20
+    metric = _metric_class(metric_name)(transform=transform)
+    scalar_func = metric.func(metric)
+    kernel = VECTORIZED_METRIC_FUNCS[metric_name]
+
+    p_mat, s_mat = _gappy_matrices(reps, n)
+
+    expected = np.array([
+        scalar_func(pd.Series(p_mat[r]), pd.Series(s_mat[r]))
+        for r in range(reps)
+    ])
+    actual = kernel(p_mat.copy(), s_mat.copy(), metric)
+
+    np.testing.assert_allclose(
+        actual, expected, rtol=1e-9, atol=1e-12, equal_nan=True
+    )
+
+
+def test_pairwise_mask_applied_without_transform():
+    """The mask must be pairwise, not per-series, even with no transform.
+
+    p and s are non-finite at different indices, so a per-series mask would
+    make relative_mean a ratio of means taken over different rows.
+    """
+    p = np.array([[1.0, 2.0, np.nan, 4.0]])
+    s = np.array([[2.0, np.nan, 6.0, 8.0]])
+    metric = DeterministicMetrics.RelativeMean()      # transform=None
+
+    # Only indices 0 and 3 are finite in BOTH series.
+    expected = np.mean([2.0, 8.0]) / np.mean([1.0, 4.0])
+    kernel = VECTORIZED_METRIC_FUNCS["RelativeMean"]
+    actual = kernel(p.copy(), s.copy(), metric)
+
+    assert actual[0] == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("n", [10, 30, 182, 1000])
+@pytest.mark.parametrize("metric_name", ["PearsonCorrelation", "Rsquared"])
+def test_correlation_stays_within_unit_interval(metric_name, n):
+    """A correlation coefficient cannot exceed 1, on either path.
+
+    The ``add_epsilon`` branch used to divide np.cov's default ddof=1
+    covariance by ddof=0 standard deviations. Those do not cancel, so the
+    result was ``r * n/(n-1)`` -- 1.110 at n=10 on well-correlated data, which
+    is not a correlation at all. Both paths now use a consistent ddof=0, so
+    the branch differs from the np.corrcoef branch only by the +EPSILON guard.
+    """
+    rng = np.random.default_rng(11)
+    p = np.abs(rng.lognormal(2, 1, n)) + 0.1
+    s = p * rng.uniform(0.9, 1.1, n)          # near-perfect correlation
+    r_true = np.corrcoef(s, p)[0][1]
+    if metric_name == "Rsquared":
+        r_true = r_true ** 2
+
+    metric = _metric_class(metric_name)(add_epsilon=True)
+    scalar = metric.func(metric)(pd.Series(p), pd.Series(s))
+
+    assert abs(scalar) <= 1.0, f"scalar {metric_name} = {scalar} exceeds 1.0"
+    assert scalar == pytest.approx(r_true, rel=1e-5)
+
+    # Rsquared has no kernel yet; this half starts asserting when one is added.
+    if metric_name in VECTORIZED_METRIC_FUNCS:
+        kernel = VECTORIZED_METRIC_FUNCS[metric_name](
+            p[None, :].copy(), s[None, :].copy(), metric
+        )[0]
+        assert abs(kernel) <= 1.0, (
+            f"kernel {metric_name} = {kernel} exceeds 1.0"
+        )
+        assert kernel == pytest.approx(r_true, rel=1e-5)
 
 
 def test_vectorized_kernel_matches_scalar_closure_with_degenerate_rows():


### PR DESCRIPTION
Started as a question about why only 9 of 41 metrics had a vectorized bootstrap kernel. Most of the gap turned out to be incidental — but investigating found two correctness bugs and two structural ones that mattered more than the missing kernels.

**Four of these change published metric values.** Those are the parts worth reviewing closely; the 18 new kernels are the least consequential thing here.

## Breaking changes

### 1. Non-finite values are dropped from every metric, not just transformed ones

`deterministic_funcs._transform` gated its non-finite drop on `model.transform is not None`, making it the only metric path in TEEHR that kept them. What "keeping" meant depended on which NumPy call a metric happened to use, because the closures receive `pd.Series`:

| scalar call | dispatches to | NaN behavior |
| --- | --- | --- |
| `np.sum`/`mean`/`std`/`min`/`max` | **pandas** method | **skips** NaN |
| `np.median` / `np.cov` / `np.corrcoef` | numpy array path | **propagates** NaN |
| `len(p)` | — | counts NaNs |

So `relative_mean` ignored a gap while `pearson_correlation` returned NaN for the same input, and `len(p)` in the mean-error family counted rows the reduction above it had just skipped. Three of the nine shipped kernels disagreed with their closures as a result — measured at n=200 with 5% NaNs, no transform:

```
RelativeMedian          scalar nan    kernel 0.9553   MISMATCH
KlingGuptaEfficiency    scalar nan    kernel 0.8497   MISMATCH
PearsonCorrelation      scalar nan    kernel 1.0072   MISMATCH   <- above 1.0
```

`signature_funcs` and the Spark-native engine both already dropped unconditionally, so this **aligns the pandas path with the other two** rather than inventing a third behavior. ME/MAE/MSE/RMSE denominators become the valid-pair count, matching `spark_native`'s `_n`.

### 2. `pearson_correlation` / `r_squared` with `add_epsilon=True` were not correlations

That branch divided a `ddof=1` covariance (`np.cov`'s default) by `ddof=0` standard deviations. Those don't cancel:

```
r_mixed = [S/(n-1)] / [sqrt(SSp/n)·sqrt(SSs/n)] = [n/(n-1)] · r_true
```

Measured — the ratio tracks `n/(n-1)` to six decimals, and exceeds 1.0 at every n below ~1000 on well-correlated data:

| n | `r_true` | before | after | before/`r_true` | n/(n−1) |
| --- | --- | --- | --- | --- | --- |
| 10 | 0.999189 | **1.110210** | 0.999189 | 1.111111 | 1.111111 |
| 30 | 0.995037 | **1.029349** | 0.995037 | 1.034483 | 1.034483 |
| 182 | 0.997397 | **1.002908** | 0.997397 | 1.005525 | 1.005525 |
| 1000 | 0.996963 | 0.997961 | 0.996963 | 1.001001 | 1.001001 |

A Pearson coefficient is bounded by 1, so there is no reading under which the old value was one. `spark_native` already paired `covar_pop` with `stddev_pop` correctly. With consistent `ddof=0` the `add_epsilon` branch now differs from the `np.corrcoef` branch **only** by the `+EPSILON` guard — which is all `add_epsilon` is meant to change. It previously swapped the estimator too.

Affects `add_epsilon=True` only. KGE and both Mod variants are unaffected (they always take the non-epsilon path). Shifts by `n/(n-1)`, or `(n/(n-1))²` for `r_squared` — worst at small n, which is exactly where bootstrap replicate groups live.

### 3. Bootstrap quality guards now apply to single-metric requests

The sample-size / mean / variance guards lived on the shared-bootstrap path, which groups of one bypassed. So one bootstrapped metric computed on a 5-sample group, while the same metric alongside a second one returned nulls for both.

**Small or degenerate groups that previously returned a value will now return null.** Note a "group of one" is a *bootstrap-config* group — metrics differing in seed, reps, quantiles or input fields don't share one, so several bootstrapped metrics can still yield several singletons.

The guards are now configurable on the `Bootstrappers` models (`minimum_sample_size`, `minimum_mean`, `minimum_variance`), so anyone affected has an escape hatch rather than a hardcoded default. They were previously unreachable.

Covered end-to-end: filtering `value_time` brings every gage in the fixture to 27 rows while leaving mean (0.49 / 10.49 / 145.6) and variance (0.081 / 0.081 / 913.6) well above their floors, so the test isolates the sample-size guard specifically and asserts both directions — null under the default floor, populated once `minimum_sample_size` is lowered. Confirmed to fail against the old singleton bypass.

The **mean and variance guards** are covered only by a pure-python test; the fixture's values can't be pushed below those floors by filtering. Those are the ones still worth a glance on real data.

### 4. `value_time`-dependent metrics reject bootstrapping

`MaxValueTimeDelta`, `AnnualPeakRelativeBias`, `MaxValueTime`, `CenterOfTiming` and `StandardDeviationOfTiming` now raise. Resampling reorders and repeats observations, so the time axis they're defined on no longer matches their values.

The combination never worked — it failed inconsistently:

```
metric                      Stationary       Gumboot
MaxValueTimeDelta           AttributeError   TypeError
MaxValueTime                TypeError        TypeError
AnnualPeakRelativeBias      "succeeded"      TypeError
CenterOfTiming              "succeeded"      TypeError
StandardDeviationOfTiming   "succeeded"      TypeError
```

Three returned numbers computed on a scrambled time axis, which is worse than raising. Under Gumboot all five raise, because `_make_bs_object` peels the trailing `value_time` argument off for water-year blocking and never forwards it to the metric — which is also why **Gumboot isn't carved out as an exception**, despite water-year resampling genuinely preserving within-year structure. Supporting it there needs `value_time` plumbed through and resampled timestamps reconstructed: a feature, not a guard.

## Performance

The fallback gate used `all(...)`, so one metric without a kernel dragged its whole group onto the legacy loop. Since `bootstrap_group_key` deliberately excludes metric class, heterogeneous groups are the norm, and the cliff was easy to hit. Fallback is now per metric, sharing one index matrix so every metric still sees identical draws.

Groups of one also never vectorized at all — `format.py` routed them through `boot.func(ref)`, which never consulted the gate. Its comment read *"it's the same cost as the old path"*, which was the bug.

Measured, n=1000, reps=1000:

| group | legacy | new | speedup |
| --- | --- | --- | --- |
| 9 covered metrics | 1548.9 ms | 81.6 ms | **19.0×** |
| 9 covered + 1 uncovered | 2046.0 ms | 471.3 ms | **4.4×** |

Mixed-group equivalence at reps=1000: **max abs diff `0.000e+00`** — bit-identical, not merely close.

## Also in here

- **Registry 9 → 28 kernels** (21/31 deterministic, 6/10 signature). Three reuse existing kernels rather than restating a formula. Still excluded: the 7 threshold metrics (need a third input column), `SpearmanCorrelation` (batched average-rank), `FlowDurationCurveSlope` (row-dependent probability grid), and the `value_time` metrics above.
- **Default flipped to the vectorized engine**; `TEEHR_BOOTSTRAP_ENGINE=legacy` is the escape hatch. On Spark it must be set on the **executors** (`spark.executorEnv.…`), since the check runs inside the pandas UDF. An unrecognized value now warns instead of silently picking an engine.
- **`DeterministicMetrics.VariabilityRatio` is now reachable.** It was implemented, announced in a previous release, documented with its own table row and a `:class:` cross-reference, tested, and Spark-native supported — but never added to the container, so following the docs raised `AttributeError`. Its `display_name` is corrected from "Variance Ratio" to "Variability Ratio". Its formula is identical to `RelativeStandardDeviation`; that duplication is tracked separately, and sharing a kernel keeps the two from diverging meanwhile.
- **Duplicate quantiles** (`[0.5, 0.50]`) no longer raise `DUPLICATED_MAP_KEY`. Pre-existing for multi-metric groups; routing singletons through the shared path would have widened it to every bootstrap group.
- A bootstrapped threshold metric with `threshold_field_name=None` now raises the explicit `ValueError` the non-bootstrap path already did.

## Review notes

**Where the float32/float64 difference comes from.** Flipping the default broke two tests asserting exact `float32` equality against a hand-rolled `arch` run. The warehouse stores values as float32 and the legacy loop reduced in float32, while the vectorized engine casts once to float64:

```
vectorized vs legacy (float32 in)   max rel 2.59e-06
vectorized vs legacy (float64 in)   max rel 7.48e-15   <- algorithmic
legacy float64 vs legacy float32    max rel 2.59e-06
```

The engines are algorithmically identical to ~1e-15; the whole gap was input dtype, and the vectorized path is the **more** accurate. Rather than widen the tolerance to 1e-4 to fit degenerate log-transform replicates where KGE reaches −123, the manual runs now cast to float64 so the comparison is like-for-like and the tolerance stays tight at 1e-6. Gumboot keeps exact float32 equality, since the engine can't apply to it.

**Tests are registry-driven**, so a future kernel is covered the moment it's registered — parity against the scalar closures across three transforms on gappy data (NaN and ±inf at offset indices, all-NaN and zero-variance rows), a no-mutation contract on every kernel (passing the matrices *uncopied*, since kernels share them across a group), registry hygiene, and a frozen name set as a rename tripwire.

**Every engine comparison names both engines explicitly.** Five tests previously selected legacy by *deleting* the env var, relying on the default — so flipping it would have turned legacy-vs-vectorized comparisons into vectorized-vs-vectorized ones that pass while testing nothing. Verified by forcing the default each way: only `test_engine_flag_defaults_to_*` changes result.

**Verification run locally:** 280 in `tests/query`, plus 135 passed / 2 skipped across `evaluations`, `examples`, `visualization`, `validation`, `writer`, `generate`, `load` and `migrations`. `fetch`/`download` skipped (network) — CI covers those.

⚠️ **The last green CI run predates the final four commits** — the `value_time` guard, the configurable guards, the `VariabilityRatio` registration, and the end-to-end guard test. Those touch `models/base.py` and changed a hard-coded column count, so a fresh run is doing real work rather than re-confirming.

## Follow-ups, deliberately not here

- `VariabilityRatio` / `RelativeStandardDeviation` duplication (tracked separately)
- Supporting `value_time` metrics under Gumboot
- `ConfusionMatrix` + bootstrap is broken today — its closure returns a dict, so `np.asarray(..., dtype=float)` should raise. Untested, unchanged by this PR.
